### PR TITLE
Fix sort when sorting on meta field (new attempt)

### DIFF
--- a/source/php/Module/Posts/Posts.php
+++ b/source/php/Module/Posts/Posts.php
@@ -349,6 +349,7 @@ class Posts extends \Modularity\Module
             );
 
             $sortBy = 'meta_key';
+            $getPostsArgs['orderby'] = $orderby;
         }
 
         // Taxonomy filter


### PR DESCRIPTION
Here is a new try to fix the sort when using a meta field. The previous attempt just fixed a warning and might fixed something with `http_build_query($filters);` in e.g `modularity-mod-posts-index.php` but not tested.

I must say I don't fully grok the code in `getPosts()` or the code in `modularity-mod-posts.php`. It might just be the naming you use ($orderby, $orderBy, $sortBy) or it could actually use some refactoring. Anyway, this seems to actually fix the sorting of posts.