### PR TITLE
Fix sort by meta

### DIFF
--- a/source/php/Module/Posts/Posts.php
+++ b/source/php/Module/Posts/Posts.php
@@ -588,27 +588,28 @@ class Posts extends \Modularity\Module
             'post_type' => 'any'
         );
 
+        // Sort by meta key
+        if (strpos($orderby, '_metakey_') === 0) {
+            $orderby_key = substr($orderby, strlen('_metakey_'));
+            $orderby = 'order_clause';
+            $metaQuery = array(
+                array(
+                    'relation' => 'OR',
+                    'order_clause' => array(
+                        'key' => $orderby_key,
+                        'compare' => 'EXISTS'
+                    ),
+                    array(
+                        'key' => $orderby_key,
+                        'compare' => 'NOT EXISTS'
+                    )
+                )
+            );
+        }
+
         if ($orderby != 'false') {
             $getPostsArgs['order'] = $order;
             $getPostsArgs['orderby'] = $orderby;
-        }
-
-        // Sort by meta key
-        if (strpos($orderby, '_metakey_') > -1) {
-            $orderby = str_replace('_metakey_', '', $orderby);
-            $metaQuery = array(
-                'relation' => 'OR',
-                array(
-                    'key' => $orderby,
-                    'compare' => 'EXISTS'
-                ),
-                array(
-                    'key' => $orderby,
-                    'compare' => 'NOT EXISTS'
-                )
-            );
-
-            $orderby = 'meta_key';
         }
 
         // Taxonomy filter


### PR DESCRIPTION
See https://github.com/helsingborg-stad/Modularity/issues/15 and https://github.com/helsingborg-stad/Modularity/pull/16 for background on this.

I also change the logic around _meta_key_ check. This now checks that it is a prefix, not just part of the string. I think that is more correct.

I have not tested this extensively (for example with NULL values) but it works for the date sort used for events on hoor.se