### PR TITLE
Avoid error log message in wp-admin

### DIFF
--- a/templates/editor/modularity-enabled-modules.php
+++ b/templates/editor/modularity-enabled-modules.php
@@ -1,6 +1,8 @@
 <div class="modularity-modules">
     <?php foreach ($modules as $moduleId => $module) : ?>
-    <div class="modularity-module modularity-js-draggable" data-module-id="<?php echo $moduleId; ?>" data-sidebar-incompability='<?php echo is_array($module['sidebar_incompability']) ? json_encode($module['sidebar_incompability']) : ''; ?>'>
+    <div class="modularity-module modularity-js-draggable"
+         data-module-id="<?php echo $moduleId; ?>"
+         data-sidebar-incompability='<?php echo (isset($module['sidebar_incompability']) && is_array($module['sidebar_incompability'])) ? json_encode($module['sidebar_incompability']) : ''; ?>'>
         <span class="modularity-module-icon">
             <?php echo modularity_decode_icon($module); ?>
         </span>


### PR DESCRIPTION
Check if module array has property set before using it.
Cleaning up messy row to multiple.