### PR TITLE
MU-Plugin fail and generates an admin nag

### DIFF
--- a/source/php/Helper/Acf.php
+++ b/source/php/Helper/Acf.php
@@ -25,9 +25,7 @@ class Acf
     {
         include_once ABSPATH . 'wp-admin/includes/plugin.php';
 
-        if (!is_plugin_active('advanced-custom-fields-pro/acf.php')
-            && !is_plugin_active('advanced-custom-fields/acf.php')
-        ) {
+        if (!class_exists('acf')) {
             require_once MODULARITY_PATH . 'plugins/acf/acf.php';
 
             add_action('admin_notices', function () {

--- a/source/php/Helper/Post.php
+++ b/source/php/Helper/Post.php
@@ -129,4 +129,29 @@ class Post
 
         return false;
     }
+
+    /**
+     * Get all (or area specific) modules posts attached to the post/page from given post_id
+     *
+     * @param $post_id
+     * @param null $selected_area
+     * @return array
+     */
+    public static function getPostModules($post_id, $selected_area = null)
+    {
+        $result = [];
+        $areas = get_post_meta($post_id, 'modularity-modules', true);
+        if ($areas) {
+            foreach ($areas as $key => $area) {
+                if ($selected_area == null || $selected_area == $key) {
+                    if ($area) {
+                        foreach ($area as $modules) {
+                            $result[] = $modules;
+                        }
+                    }
+                }
+            }
+        }
+        return $result;
+    }
 }


### PR DESCRIPTION
Check for the "acf" class instead of check if plugin is active because if you place ACF as a mu-plugin (Must Use) then this check will false even if active.

This is how ACF themselves check for its active state.