### PR TITLE
Typo in Display.php

### DIFF
--- a/source/php/Display.php
+++ b/source/php/Display.php
@@ -450,7 +450,7 @@ class Display
             return $post;
         }
 
-        $post->post_content = preg_replace('/\[modularity(.*)\]/', '', $content);
+        $post->post_content = preg_replace('/\[modularity(.*)\]/', '', $post->post_content);
         return $post;
     }
 


### PR DESCRIPTION
Perhaps a typo causing render error when using "the_post" in WP REST functions / prepare.
$content is not in current scope of function. Think you mean $post->post_content.