### PR TITLE
Variable missing in context

### DIFF
--- a/source/php/Display.php
+++ b/source/php/Display.php
@@ -450,7 +450,7 @@ class Display
             return $post;
         }
 
-        $post->post_content = preg_replace('/\[modularity(.*)\]/', '', $content);
+        $post->post_content = preg_replace('/\[modularity(.*)\]/', '', $post->post_content);
         return $post;
     }
 


### PR DESCRIPTION
Seems like you are missing to grab the post_content as subject for replace.
This causes render error when using the_post in WP Rest API