### PR TITLE
add trailing slash to list of template directories

### DIFF
--- a/source/php/Display.php
+++ b/source/php/Display.php
@@ -188,6 +188,8 @@ class Display
             "",
             get_stylesheet_directory(),
             get_template_directory(),
+            get_stylesheet_directory() . '/',
+            get_template_directory() . '/',
             get_stylesheet_directory() . '/views/',
             get_template_directory() . '/views/',
         ));


### PR DESCRIPTION
We're using Modularity with [Sage](https://roots.io/sage/) and `getPostTemplate()` returns `views/template-custom.blade.php`, resulting in `../themes/theme/resourcesviews/template.blade.php`.