### PR TITLE
add wider array of template paths

### DIFF
--- a/source/php/Helper/Wp.php
+++ b/source/php/Helper/Wp.php
@@ -78,8 +78,10 @@ class Wp
     public static function findCoreTemplates($templates = null, $extension = false)
     {
         $paths = apply_filters('Modularity/CoreTemplatesSearchPaths', array(
-            get_stylesheet_directory(),
-            get_template_directory()
+            get_stylesheet_directory() . '/',
+            get_template_directory() . '/',
+            get_stylesheet_directory() . '/views/',
+            get_template_directory() . '/views/'
         ));
 
         $fileExt = apply_filters('Modularity/CoreTemplatesSearchFileExtension', array(

--- a/source/php/Helper/Wp.php
+++ b/source/php/Helper/Wp.php
@@ -11,8 +11,10 @@ class Wp
     public static function getCoreTemplates($extension = false)
     {
         $paths = apply_filters('Modularity/CoreTemplatesSearchPaths', array(
-            get_stylesheet_directory(),
-            get_template_directory()
+            get_stylesheet_directory() . '/',
+            get_template_directory() . '/',
+            get_stylesheet_directory() . '/views/',
+            get_template_directory() . '/views/'
         ));
 
         $fileExt = apply_filters('Modularity/CoreTemplatesSearchFileExtension', array(


### PR DESCRIPTION
Basically having the same issue as in #30 (using Sage) resulting in templates like page.blade.php not showing up under "Template areas".