### PR TITLE
Display expandable list content by default if no javascript

### DIFF
--- a/source/php/Module/Posts/views/expandable-list.blade.php
+++ b/source/php/Module/Posts/views/expandable-list.blade.php
@@ -65,6 +65,11 @@
                 @endif
             </label>
             <div class="accordion-content">
+                <noscript>
+                    <style type="text/css">
+                        .accordion-content { display: block; }
+                    </style>
+                </noscript>
                 <article>
                     <?php echo apply_filters('the_content', $post->post_content); ?>
                 </article>


### PR DESCRIPTION
Ensures the expandable list contents can be read without JavaScript.