### PR TITLE
Feature/module restrictions

### DIFF
--- a/source/php/Editor.php
+++ b/source/php/Editor.php
@@ -224,6 +224,7 @@ class Editor extends \Modularity\Options
 
         $activeAreas = $this->getActiveAreas($template);
 
+
         // Add no active sidebars message if no active sidebars exists
         if (count($activeAreas) === 0) {
             add_meta_box(
@@ -264,7 +265,14 @@ class Editor extends \Modularity\Options
     {
         $originalTemplate = $template;
         $options = get_option('modularity-options');
-        $active = isset($options['enabled-areas'][$template]) ? $options['enabled-areas'][$template] : array();
+
+        // Use the ACF-options for module areas if activated
+        if(get_field('acf_module_areas', 'option')) {
+            $template = str_replace('.blade.php', '', $template);
+            $active = get_field($template . '_active_sidebars', 'option');
+        } else {
+            $active = isset($options['enabled-areas'][$template]) ? $options['enabled-areas'][$template] : array();
+        }
 
         self::$isEditing['template'] = $template;
 

--- a/source/php/Helper/Post.php
+++ b/source/php/Helper/Post.php
@@ -32,7 +32,7 @@ class Post
      * Gets the post template of the current editor page
      * @return string Template slug
      */
-    public static function getPostTemplate($id = null)
+    public static function getPostTemplate($id = null, $trim = false)
     {
         if ($archive = self::isArchive()) {
             return $archive;
@@ -64,6 +64,8 @@ class Post
         if (!$template) {
             $template = self::detectCoreTemplate($post);
         }
+
+        $template = $trim ? str_replace('.blade.php', '', $template) : $template;
 
         return $template;
     }

--- a/source/php/Options/AcfFields/acf-module-restrictions.php
+++ b/source/php/Options/AcfFields/acf-module-restrictions.php
@@ -189,7 +189,7 @@ function generateFields() {
         );
         array_push($template_fields, $active_sidebars);
 
-        $template_sidebars = get_field($template . '_active_sidebars', 'option');
+        $template_sidebars = get_field($id . '_active_sidebars', 'option');
         if($template_sidebars) {
             foreach ($template_sidebars as $sidebar) {
                 $sidebar_modules = array(

--- a/source/php/Options/AcfFields/acf-module-restrictions.php
+++ b/source/php/Options/AcfFields/acf-module-restrictions.php
@@ -1,0 +1,231 @@
+<?php
+
+if( function_exists('acf_add_local_field_group') ) {
+    acf_add_local_field_group(array(
+	'key' => 'group_5b2908801bd05',
+	'title' => __('Sidebar & Module Restrictions', 'modularity'),
+	'fields' => generateFields(),
+	'location' => array(
+	    array(
+		array(
+		    'param' => 'options_page',
+		    'operator' => '==',
+		    'value' => 'acf-options-restrictive-options',
+		),
+	    ),
+	),
+	'menu_order' => 0,
+	'position' => 'acf_after_title',
+	'style' => 'default',
+	'label_placement' => 'top',
+	'instruction_placement' => 'label',
+	'hide_on_screen' => '',
+	'active' => 1,
+	'description' => '',
+    ));
+
+    acf_add_local_field_group(array(
+	'key' => 'group_5b2908801bd08',
+	'title' => __('Settings', 'modularity'),
+	'fields' => array(
+	    array(
+		'key' => 'field_acf_module_areas',
+		'label' => __('Template Areas', 'modularity'),
+		'name' => 'acf_module_areas',
+		'type' => 'true_false',
+		'instructions' => '',
+		'required' => 0,
+		'conditional_logic' => 0,
+		'wrapper' => array(
+		    'width' => '',
+		    'class' => '',
+		    'id' => '',
+		),
+		'message' => __(
+                    'Checking this will override the default module area settings.',
+                    'modularity'
+                ),
+		'default_value' => 0,
+		'ui' => 1,
+		'ui_on_text' => '',
+		'ui_off_text' => '',
+	    ),
+	    array(
+		'key' => 'field_module_restrictions',
+		'label' => __('Module Restrictions', 'modularity'),
+		'name' => 'acf_module_restrictions',
+		'type' => 'true_false',
+		'instructions' => '',
+		'required' => 0,
+		'conditional_logic' => 0,
+		'wrapper' => array(
+		    'width' => '',
+		    'class' => '',
+		    'id' => '',
+		),
+		'message' => __(
+                    'Checking this will filter the default module settings for each template.',
+                    'modularity'
+                ),
+		'default_value' => 0,
+		'ui' => 1,
+		'ui_on_text' => '',
+		'ui_off_text' => '',
+	    )
+	),
+	'location' => array(
+	    array(
+		array(
+		    'param' => 'options_page',
+		    'operator' => '==',
+		    'value' => 'acf-options-restrictive-options',
+		),
+	    ),
+	),
+	'menu_order' => 0,
+	'position' => 'acf_after_title',
+	'style' => 'default',
+	'label_placement' => 'top',
+	'instruction_placement' => 'label',
+        'hide_on_screen' => '',
+	'active' => 1,
+	'description' => '',
+    ));
+}
+
+/**
+ * Get registered sidebars and returns an assoc
+ *
+ * @return array Sidebar Options
+ */
+function getSidebars()
+{
+    global $wp_registered_sidebars;
+    $sidebar_options = array();
+
+    foreach ( $wp_registered_sidebars as $sidebar ){
+        $sidebar_options[$sidebar['id']] = $sidebar['name'];
+    }
+    return $sidebar_options;
+}
+
+/**
+ * Get available templates of the theme
+ *
+ * @return array Available Templates
+ */
+function getTemplates()
+{
+    $coreTemplates = \Modularity\Helper\Wp::getCoreTemplates();
+    $coreTemplates = apply_filters('Modularity/CoreTemplatesInTheme', $coreTemplates);
+    $customTemplates = wp_get_theme()->get_page_templates();
+
+    $templates = array_merge($coreTemplates, $customTemplates);
+
+    return $templates;
+}
+
+/**
+ * Generate or load ACF option fields for each available template
+ *
+ * @return array Option Fields corresponding to each template
+ */
+function generateFields() {
+    $template_fields = array();
+    $all_sidebars = getSidebars();
+    $available_modules = \Modularity\ModuleManager::$enabled;
+
+    foreach(getTemplates() as $id => $template) {
+        $id = str_replace('.blade.php', '', $id);
+        $accordion = array(
+            'key' => 'field_' . $id,
+            'label' => __($template, 'modularity'),
+            'name' => '',
+            'type' => 'accordion',
+            'instructions' => '',
+            'required' => 0,
+            'conditional_logic' => 0,
+            'wrapper' => array(
+                'width' => '',
+                'class' => '',
+                'id' => '',
+            ),
+            'open' => 0,
+            'multi_expand' => 0,
+            'endpoint' => 0,
+        );
+        array_push($template_fields, $accordion);
+
+        $active_sidebars = array(
+            'key' => 'field_' . $id . '-sidebars',
+            'label' => __('Active Sidebars', 'modularity'),
+            'name' => $id . '_active_sidebars',
+            'type' => 'select',
+            'instructions' => '',
+            'required' => 0,
+            'conditional_logic' => array(
+                array(
+                    array(
+                        'field' => 'field_acf_module_areas',
+                        'operator' => '==',
+                        'value' => '1',
+                    ),
+                ),
+            ),
+            'wrapper' => array(
+                'width' => '',
+                'class' => '',
+                'id' => '',
+            ),
+            'choices' => $all_sidebars,
+            'default_value' => array(
+            ),
+            'allow_null' => 0,
+            'multiple' => 1,
+            'ui' => 1,
+            'return_format' => 'value',
+            'ajax' => 0,
+            'placeholder' => '',
+        );
+        array_push($template_fields, $active_sidebars);
+
+        $template_sidebars = get_field($template . '_active_sidebars', 'option');
+        if($template_sidebars) {
+            foreach ($template_sidebars as $sidebar) {
+                $sidebar_modules = array(
+	            'key' => 'field_' . $id . $sidebar,
+		    'label' => __($all_sidebars[$sidebar], 'modularity'),
+		    'name' => $id . '-' . $sidebar,
+		    'type' => 'select',
+		    'instructions' => '',
+		    'required' => 0,
+		    'conditional_logic' => array(
+			array(
+			    array(
+				'field' => 'field_module_restrictions',
+				'operator' => '==',
+				'value' => '1',
+			    ),
+			),
+		    ),
+		    'wrapper' => array(
+			'width' => '',
+			'class' => '',
+			'id' => '',
+		    ),
+		    'choices' => $available_modules,
+		    'default_value' => array(
+		    ),
+		    'allow_null' => 0,
+		    'multiple' => 1,
+		    'ui' => 1,
+		    'return_format' => 'array',
+		    'ajax' => 0,
+		    'placeholder' => '',
+		);
+		array_push($template_fields, $sidebar_modules);
+	    }
+	}
+    }
+    return $template_fields;
+}

--- a/source/php/Options/General.php
+++ b/source/php/Options/General.php
@@ -25,6 +25,91 @@ class General extends \Modularity\Options
                 'options.php?page=modularity-editor&id=search'
             );
         });
+
+        acf_add_options_sub_page(array(
+            'page_title'    => __('Restrictive Options', 'modularity'),
+            'menu_title'    => __('Restrictive Options', 'modularity'),
+            'parent_slug'   => 'modularity',
+            'capability'    => 'administrator',
+            'redirect'      => false,
+            'icon_url'      => ''
+        ));
+
+        /**
+         * Initialize ACF fields for restrictive options. This needs to be
+         * called after the Add() action in the municipio template helper in
+         * order to find custom templates. (Thereby the priority of 1000).
+         */
+        add_action(
+            'init',
+            function() {
+                $acfPath = 'source/php/Options/AcfFields/acf-module-restrictions.php';
+	        include MODULARITY_PATH . $acfPath;
+	    },
+	    1000
+        );
+
+	if(get_field('acf_module_restrictions', 'option')) {
+	    add_filter(
+		'Modularity/Editor/SidebarIncompability',
+		array($this, 'sidebarIncompatibility'),
+		20,
+		2
+	    );
+	    add_action('edit_form_top', function () {
+		\Modularity\ModuleManager::$enabled = $this->moduleRestriction();
+	    });
+	}
+    }
+
+    /**
+     * Filters the sidebar incompatibility list based on the restrictive
+     * options page.
+     *
+     * @return array Module Specification
+     */
+    public function sidebarIncompatibility($moduleSpecification, $modulePostType) {
+        $template = \Modularity\Helper\Post::getPostTemplate(null, true);
+        $template_sidebars = get_field($template . '_active_sidebars', 'option');
+
+	if($template_sidebars) {
+	    $sidebarIncompatibilities = array_flip($template_sidebars);
+
+	    foreach($template_sidebars as $sidebar) {
+		$modules = get_field($template . '-' . $sidebar, 'option');
+		foreach($modules as $module) {
+		    if($modulePostType == $module['label']) {
+			unset($sidebarIncompatibilities[$sidebar]);
+		    }
+		}
+	    }
+	    $moduleSpecification['sidebar_incompability'] = array_keys($sidebarIncompatibilities);
+	}
+	return $moduleSpecification;
+    }
+
+    /**
+     * Decides what modules are available for the current template
+     * based on the restrictive options page (if enabled).
+     *
+     * @return array Enabled modules
+     */
+    public function moduleRestriction() {
+	$enabledMods = array();
+	$template = \Modularity\Helper\Post::getPostTemplate(null, true);
+	$sidebars = get_field($template . '_active_sidebars', 'option');
+
+	if(count($sidebars) > 0) {
+	    foreach($sidebars as $sidebar) {
+		$modules = get_field($template . '-' . $sidebar, 'option');
+		if($modules) {
+		    foreach($modules as $module) {
+			array_push($enabledMods, $module['label']);
+		    }
+		}
+	    }
+	}
+	return $enabledMods;
     }
 
     /**
@@ -33,68 +118,68 @@ class General extends \Modularity\Options
      */
     public function addMetaBoxes()
     {
-        // Publish
-        add_meta_box(
-            'modularity-mb-publish',
-            __('Save options', 'modularity'),
-            function () {
-                $templatePath = \Modularity\Helper\Wp::getTemplate('publish', 'options/partials');
-                include $templatePath;
-            },
-            $this->screenHook,
-            'side'
-        );
+	// Publish
+	add_meta_box(
+	    'modularity-mb-publish',
+	    __('Save options', 'modularity'),
+	    function () {
+		$templatePath = \Modularity\Helper\Wp::getTemplate('publish', 'options/partials');
+		include $templatePath;
+	    },
+	    $this->screenHook,
+	    'side'
+	);
 
-        // Core options
-        add_meta_box(
-            'modularity-mb-core-options',
-            __('Core options', 'modularity'),
-            function () {
-                $templatePath = \Modularity\Helper\Wp::getTemplate('core-options', 'options/partials');
-                include $templatePath;
-            },
-            $this->screenHook,
-            'normal'
-        );
+	// Core options
+	add_meta_box(
+	    'modularity-mb-core-options',
+	    __('Core options', 'modularity'),
+	    function () {
+		$templatePath = \Modularity\Helper\Wp::getTemplate('core-options', 'options/partials');
+		include $templatePath;
+	    },
+	    $this->screenHook,
+	    'normal'
+	);
 
-        if (has_action('Modularity/Options/Module')) {
-            add_meta_box(
-                'modularity-mb-module-options',
-                __('Module options', 'modularity'),
-                function () {
-                    do_action('Modularity/Options/Module');
-                },
-                $this->screenHook,
-                'normal'
-            );
-        }
+	if (has_action('Modularity/Options/Module')) {
+	    add_meta_box(
+		'modularity-mb-module-options',
+		__('Module options', 'modularity'),
+		function () {
+		    do_action('Modularity/Options/Module');
+		},
+		$this->screenHook,
+		'normal'
+	    );
+	}
 
-        // Modules
-        add_meta_box(
-            'modularity-mb-post-types',
-            __('Post types', 'modularity'),
-            array($this, 'metaBoxPostTypes'),
-            $this->screenHook,
-            'normal'
-        );
+	// Modules
+	add_meta_box(
+	    'modularity-mb-post-types',
+	    __('Post types', 'modularity'),
+	    array($this, 'metaBoxPostTypes'),
+	    $this->screenHook,
+	    'normal'
+	);
 
-        // Templates and areas
-        add_meta_box(
-            'modularity-mb-template-areas',
-            __('Template areas', 'modularity'),
-            array($this, 'metaBoxTemplateAreas'),
-            $this->screenHook,
-            'normal'
-        );
+	// Templates and areas
+	add_meta_box(
+	    'modularity-mb-template-areas',
+	    __('Template areas', 'modularity'),
+	    array($this, 'metaBoxTemplateAreas'),
+	    $this->screenHook,
+	    'normal'
+	);
 
-        // Modules
-        add_meta_box(
-            'modularity-mb-modules',
-            __('Modules', 'modularity'),
-            array($this, 'metaBoxModules'),
-            $this->screenHook,
-            'normal'
-        );
+	// Modules
+	add_meta_box(
+	    'modularity-mb-modules',
+	    __('Modules', 'modularity'),
+	    array($this, 'metaBoxModules'),
+	    $this->screenHook,
+	    'normal'
+	);
     }
 
     /**
@@ -103,20 +188,19 @@ class General extends \Modularity\Options
      */
     public function metaBoxTemplateAreas()
     {
-        global $wp_registered_sidebars;
-        global $modularityOptions;
+	global $wp_registered_sidebars;
+	global $modularityOptions;
 
-        usort($wp_registered_sidebars, function ($a, $b) {
-            return $a['name'] > $b['name'];
-        });
+	usort($wp_registered_sidebars, function ($a, $b) {
+	    return $a['name'] > $b['name'];
+	});
 
-        $coreTemplates = \Modularity\Helper\Wp::getCoreTemplates();
-        $coreTemplates = apply_filters('Modularity/CoreTemplatesInTheme', $coreTemplates);
-        $customTemplates = get_page_templates();
+	$coreTemplates = \Modularity\Helper\Wp::getCoreTemplates();
+	$coreTemplates = apply_filters('Modularity/CoreTemplatesInTheme', $coreTemplates);
+	$customTemplates = get_page_templates();
+	$templates = array_merge($coreTemplates, $customTemplates);
 
-        $templates = array_merge($coreTemplates, $customTemplates);
-
-        include MODULARITY_TEMPLATE_PATH . 'options/partials/modularity-template-areas.php';
+	include MODULARITY_TEMPLATE_PATH . 'options/partials/modularity-template-areas.php';
     }
 
     /**
@@ -125,33 +209,33 @@ class General extends \Modularity\Options
      */
     public function metaBoxPostTypes()
     {
-        global $modularityOptions;
-        $enabled = isset($modularityOptions['enabled-post-types']) && is_array($modularityOptions['enabled-post-types']) ? $modularityOptions['enabled-post-types'] : array();
+	global $modularityOptions;
+	$enabled = isset($modularityOptions['enabled-post-types']) && is_array($modularityOptions['enabled-post-types']) ? $modularityOptions['enabled-post-types'] : array();
 
-        $postTypes = array_filter(get_post_types(), function ($item) {
-            $disallowed = array_merge(
-                array_keys(\Modularity\ModuleManager::$available),
-                array(
-                    'attachment',
-                    'revision',
-                    'nav_menu_item',
-                    'custom_css',
-                    'customize_changeset'
-                )
-            );
+	$postTypes = array_filter(get_post_types(), function ($item) {
+	    $disallowed = array_merge(
+		array_keys(\Modularity\ModuleManager::$available),
+		array(
+		    'attachment',
+		    'revision',
+		    'nav_menu_item',
+		    'custom_css',
+		    'customize_changeset'
+		)
+	    );
 
-            if (in_array($item, $disallowed)) {
-                return false;
-            }
+	    if (in_array($item, $disallowed)) {
+		return false;
+	    }
 
-            if (substr($item, 0, 4) == 'acf-') {
-                return false;
-            }
+	    if (substr($item, 0, 4) == 'acf-') {
+		return false;
+	    }
 
-            return true;
-        });
+	    return true;
+	});
 
-        include MODULARITY_TEMPLATE_PATH . 'options/partials/modularity-post-types.php';
+	include MODULARITY_TEMPLATE_PATH . 'options/partials/modularity-post-types.php';
     }
 
     /**
@@ -160,16 +244,16 @@ class General extends \Modularity\Options
      */
     public function metaBoxModules()
     {
-        $available = \Modularity\ModuleManager::$available;
+	$available = \Modularity\ModuleManager::$available;
 
-        uasort($available, function ($a, $b) {
-            return strcmp($a['labels']['name'], $b['labels']['name']);
-        });
+	uasort($available, function ($a, $b) {
+	    return strcmp($a['labels']['name'], $b['labels']['name']);
+	});
 
-        global $modularityOptions;
-        $enabled = isset($modularityOptions['enabled-modules']) && is_array($modularityOptions['enabled-modules']) ? $modularityOptions['enabled-modules'] : array();
+	global $modularityOptions;
+	$enabled = isset($modularityOptions['enabled-modules']) && is_array($modularityOptions['enabled-modules']) ? $modularityOptions['enabled-modules'] : array();
 
-        $templatePath = \Modularity\Helper\Wp::getTemplate('modules', 'options/partials');
-        include $templatePath;
+	$templatePath = \Modularity\Helper\Wp::getTemplate('modules', 'options/partials');
+	include $templatePath;
     }
 }


### PR DESCRIPTION
I vårat projekt har vi haft behovet att på en template-basis anpassa vilka moduler och modul-areor som ska gå att användas. Alltså ett slags "white list"-tänk, med lite mer kontroll.

I skärmdumpen visas ett exempel på vilka moduler-areor som finns tillgängliga för "single", samt vilka moduler som får läggas i respektive area.

Skulle ni välja att inkludera den i Modularity så är det ingenting som behöver användas eller ändras ur ett användarperspektiv. Man måste manuellt aktivera det "restriktiva" läget, så det är kompatibelt med det "vanliga" sättet att aktivera/inaktivera moduler.

Har ni funderingar eller synpunkter så säg gärna till!

![Restrictive Options](https://user-images.githubusercontent.com/9434836/52285834-61c23a80-2967-11e9-9c96-3d669c5f89ae.png)
