### PR TITLE
Change how Modularity checks for ACF

### DIFF
--- a/source/php/Helper/Acf.php
+++ b/source/php/Helper/Acf.php
@@ -23,11 +23,7 @@ class Acf
      */
     public function includeAcf()
     {
-        include_once ABSPATH . 'wp-admin/includes/plugin.php';
-
-        if (!is_plugin_active('advanced-custom-fields-pro/acf.php')
-            && !is_plugin_active('advanced-custom-fields/acf.php')
-        ) {
+        if (!(class_exists('acf_pro') || class_exists('ACF'))) {
             require_once MODULARITY_PATH . 'plugins/acf/acf.php';
 
             add_action('admin_notices', function () {


### PR DESCRIPTION
Checking if the classes 'acf_pro' or 'ACF' are loaded instead of using
'is_plugin_active'. This is more reliable since the 'is_plugin_active'
function for instance won't notice 'must-use' plugins.