### PR TITLE
Fix double escaping of post titles

### DIFF
--- a/source/php/Module/InheritPost/views/inheritposts.blade.php
+++ b/source/php/Module/InheritPost/views/inheritposts.blade.php
@@ -4,7 +4,7 @@
         <h1>{{ $module->post_title }}</h1>
     @endif
 
-    <h2>{{ apply_filters('the_title', $inherit->post_title) }}</h2>
+    <h2>{!! apply_filters('the_title', $inherit->post_title) !!}</h2>
     {!! apply_filters('the_content', $inherit->post_content) !!}
 </article>
 @endif

--- a/source/php/Module/Posts/views/expandable-list.blade.php
+++ b/source/php/Module/Posts/views/expandable-list.blade.php
@@ -34,7 +34,7 @@
                     <span class="accordion-table">
                     @if (isset($post->column_values) && !empty($post->column_values))
                         @if ($posts_hide_title_column)
-                        <span class="column-header">{{ apply_filters('the_title', $post->post_title) }}</span>
+                        <span class="column-header">{!! apply_filters('the_title', $post->post_title) !!}</span>
                         @endif
 
                         @if (is_array($posts_list_column_titles))

--- a/source/php/Module/Posts/views/grid.blade.php
+++ b/source/php/Module/Posts/views/grid.blade.php
@@ -29,7 +29,7 @@
                     @endif
 
                     @if (in_array('title', $posts_fields))
-                    <h3 class="post-title">{{ apply_filters('the_title', $post->post_title) }}</h3>
+                    <h3 class="post-title">{!! apply_filters('the_title', $post->post_title) !!}</h3>
                     @endif
                 </div>
 

--- a/source/php/Module/Posts/views/index.blade.php
+++ b/source/php/Module/Posts/views/index.blade.php
@@ -27,7 +27,7 @@
 
             <div class="box-content">
                 @if (in_array('title', $posts_fields))
-                <h5 class="box-index-title link-item">{{ apply_filters('the_title', $post->post_title) }}</h5>
+                <h5 class="box-index-title link-item">{!! apply_filters('the_title', $post->post_title) !!}</h5>
                 @endif
 
                 @if (in_array('excerpt', $posts_fields))

--- a/source/php/Module/Posts/views/items.blade.php
+++ b/source/php/Module/Posts/views/items.blade.php
@@ -27,7 +27,7 @@
 
                 <div class="box-content">
                     @if (in_array('title', $posts_fields))
-                    <h5 class="link-item link-item-light">{{ apply_filters('the_title', $post->post_title) }}</h5>
+                    <h5 class="link-item link-item-light">{!! apply_filters('the_title', $post->post_title) !!}</h5>
                     @endif
 
                     @if (in_array('date', $posts_fields) && $posts_data_source !== 'input')

--- a/source/php/Module/Posts/views/list.blade.php
+++ b/source/php/Module/Posts/views/list.blade.php
@@ -15,7 +15,7 @@
                     <a href="{{ $posts_data_source === 'input' ? $post->permalink : get_permalink($post->ID) }}">
                 @endif
                     @if (in_array('title', $posts_fields))
-                        <span class="link-item title">{{ apply_filters('the_title', $post->post_title) }}</span>
+                        <span class="link-item title">{!! apply_filters('the_title', $post->post_title) !!}</span>
                     @endif
 
                     @if (in_array('date', $posts_fields) && $posts_data_source !== 'input')

--- a/source/php/Module/Posts/views/news.blade.php
+++ b/source/php/Module/Posts/views/news.blade.php
@@ -30,7 +30,7 @@
 
             <div class="box-content">
                 @if (in_array('title', $posts_fields))
-                <h3 class="text-highlight">{{ apply_filters('the_title', $post->post_title) }}</h3>
+                <h3 class="text-highlight">{!! apply_filters('the_title', $post->post_title) !!}</h3>
                 @endif
 
                 @if (in_array('excerpt', $posts_fields))


### PR DESCRIPTION
Post title filters in WordPress change certain characters to HTML-encoded variants. These were sometimes also escaped by Blade, resulting in the HTML-encoded variants being visible to end users.

The post title filters do not escape HTML tags from the title. While this could cause issues, the HTML-encoded characters makes it so that titles cannot be escaped without first disabling some of the built-in
post title filters.

Post titles are usually not escaped in Modularity, so this commit just makes that the case in all other places as well.