### PR TITLE
Fix another double escaping of post titles

### DIFF
--- a/source/php/Module/Posts/views/circular.blade.php
+++ b/source/php/Module/Posts/views/circular.blade.php
@@ -28,7 +28,7 @@
 
             <div class="box-content">
                 @if (in_array('title', $posts_fields))
-                <h3>{{ apply_filters('the_title', $post->post_title) }}</h3>
+                <h3>{!! apply_filters('the_title', $post->post_title) !!}</h3>
                 @endif
 
                 @if (in_array('excerpt', $posts_fields))


### PR DESCRIPTION
Forgot to save a file yesterday!

See #46 for more details.