### PR TITLE
Fix for camelCase Directories

### DIFF
--- a/source/php/Display.php
+++ b/source/php/Display.php
@@ -57,15 +57,9 @@ class Display
      */
     public function renderView($view, $data = array()): string
     {
-        // Get Module directory before adding to filter
-        $moduleName = $this->getModuleDirectory($data['post_type']);
-
-        if ($moduleName === null){
-            return  false;
-        }
 
         // Adding Module path to filter
-        $moduleView = MODULARITY_PATH . 'source/php/Module/' . $moduleName . '/views';
+        $moduleView = MODULARITY_PATH . 'source/php/Module/' . $this->getModuleDirectory($data['post_type']) . '/views';
         $externalViewPaths = apply_filters('/Modularity/externalViewPath', []);
 
         if (isset($externalViewPaths[$data['post_type']])) {

--- a/source/php/Display.php
+++ b/source/php/Display.php
@@ -29,6 +29,27 @@ class Display
     }
 
     /**
+     * Get module directory by post-type
+     * @param $postType
+     * @return mixed|null
+     */
+    public function getModuleDirectory($postType)
+    {
+        if (!is_dir(MODULARITY_PATH . 'source/php/Module/')) {
+            return null;
+        }
+
+        foreach (glob(MODULARITY_PATH . 'source/php/Module/*') as $dir) {
+            $pathinfo = pathinfo($dir);
+            if (strtolower(str_replace('mod-', '', $postType)) === strtolower($pathinfo['filename'])) {
+                return $pathinfo['filename'];
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * @param $view
      * @param array $data
      * @return bool
@@ -36,9 +57,15 @@ class Display
      */
     public function renderView($view, $data = array()): string
     {
-        $moduleName = ucFirst((str_replace('mod-', '', $data['post_type'])));
-        $moduleView = MODULARITY_PATH . 'source/php/Module/' . $moduleName . '/views';
+        // Get Module directory before adding to filter
+        $moduleName = $this->getModuleDirectory($data['post_type']);
 
+        if ($moduleName === null){
+            return  false;
+        }
+
+        // Adding Module path to filter
+        $moduleView = MODULARITY_PATH . 'source/php/Module/' . $moduleName . '/views';
         $externalViewPaths = apply_filters('/Modularity/externalViewPath', []);
 
         if (isset($externalViewPaths[$data['post_type']])) {


### PR DESCRIPTION
New method getModuleDirectory()
Getting correct module directory name by checking directories vs post type