### PR TITLE
3.0/feature/module blocks

### DIFF
--- a/source/php/BlockManager.php
+++ b/source/php/BlockManager.php
@@ -4,6 +4,7 @@
     class BlockManager {
 
         public $modules = [];
+        public $classes = [];
 
         public function __construct() {            
             add_filter( 'block_categories', array($this, 'filterCategories'), 10, 2 );
@@ -13,33 +14,23 @@
 
         public function filterBlockTypes($allowedBlocks) {
             $registeredBlocks = \WP_Block_Type_Registry::get_instance()->get_all_registered();
-
+            
             foreach($registeredBlocks as $type => $block) {
                 if(str_contains($type, 'core/') && $type !== 'core/freeform') {
                     unset($registeredBlocks[$type]);
-                }                
+                }                                   
+            }
+
+            foreach($this->classes as $class) {
+                if(!$class->isBlockCompatible) {
+                    unset($registeredBlocks['acf/' . $class->slug]);
+                }
             }
 
             return array_keys($registeredBlocks);                        
         }
 
-        /* public function getCategories($slugs) {
-            $categories = [];
-            foreach($slugs as $slug) {
-                $categorySlug = str_replace('mod-', '', $slug);
-                $categoryTitle = ucfirst(str_replace('-', ' ', $categorySlug));
-                $categories[] = [
-                    'slug' => $categorySlug,
-                    'title' => __( $categoryTitle, 'modularity' ),
-                    'icon' => 'wordpress'
-                ];
-            }
-
-            return $categories;
-        } */
-
-        public function filterCategories( $categories, $post ) {     
-            //$customCategories = $this->getCategories($this->modules);       
+        public function filterCategories( $categories, $post ) {            
             
             return array_merge(
                 $categories,
@@ -51,39 +42,19 @@
             );
         }
         
-        public function registerBlock($name) {
-        $modules = ['slider', 'notice'];
-        
-            /* foreach ( $this->modules as $key => &$name) {
-                $name = str_replace('mod-', '', $name);               
-            } */
-
+        public function registerBlocks() {
             // Register module as a block
-            if( function_exists('acf_register_block_type') ) {
-                
-                    /* $moduleView = MODULARITY_PATH . 'source/php/Module/' . $name . '/views';
-                    if(!\file_exists($moduleView)) {
-                        continue;
-                    }
-                    $views = scandir($moduleView); */
-                                                            
-                    /* foreach($views as $view) {
-                        if(!str_contains($view, '.blade.php')) {
-                            continue;
-                        }
-                        $view = str_replace('.blade.php', '', $view); 
-    
-                    }   */ 
-                    
-                    
+            if( function_exists('acf_register_block_type') ) {                                
+                foreach($this->classes as $class) {
                     acf_register_block_type(array(
-                        'name'              => $name,
-                        'title'             => __($name),
+                        'name'              => $class->slug,
+                        'title'             => __($class->slug),
                         'description'       => __('A custom testimonial block.'),
                         'render_callback'   => array($this, 'renderBlock'),
                         'category'          => 'modules',
-                        'postType'          => 'mod-' . $name
+                        'moduleName'          => $class->slug
                     ));
+                }
             }
 
         }
@@ -111,14 +82,12 @@
         }
 
         public function renderBlock($block) {
-            $display = new Display();
-            $postType = \Modularity\ModuleManager::prefixSlug($block['title']);
-            $class = \Modularity\ModuleManager::$classes[$postType];
-            $module = new $class;
+            $display = new Display();            
+            $module = $this->classes[$block['moduleName']];
             $module->data = $block['data'];
             $view = str_replace('.blade.php', '', $module->template());
-            //echo '<pre>', print_r($block['data']), '</pre>';
-            $viewData = array_merge(['post_type' => $block['postType']], $module->data());
+            $view = !empty($view) ? $view : $block['moduleName'];
+            $viewData = array_merge(['post_type' => $module->moduleSlug], $module->data());
             
             echo  $display->renderView($view, $viewData);
         }

--- a/source/php/BlockManager.php
+++ b/source/php/BlockManager.php
@@ -21,12 +21,6 @@
                 }                                   
             }
 
-            foreach($this->classes as $class) {
-                if(!$class->isBlockCompatible) {
-                    unset($registeredBlocks['acf/' . $class->slug]);
-                }
-            }
-
             return array_keys($registeredBlocks);                        
         }
 
@@ -46,14 +40,16 @@
             // Register module as a block
             if( function_exists('acf_register_block_type') ) {                                
                 foreach($this->classes as $class) {
-                    acf_register_block_type(array(
-                        'name'              => $class->slug,
-                        'title'             => __($class->slug),
-                        'description'       => __('A custom testimonial block.'),
-                        'render_callback'   => array($this, 'renderBlock'),
-                        'category'          => 'modules',
-                        'moduleName'          => $class->slug
-                    ));
+                    if($class->isBlockCompatible) {
+                        acf_register_block_type(array(
+                            'name'              => $class->slug,
+                            'title'             => __($class->slug),
+                            'description'       => __('A custom testimonial block.'),
+                            'render_callback'   => array($this, 'renderBlock'),
+                            'category'          => 'modules',
+                            'moduleName'          => $class->slug
+                        ));
+                    }
                 }
             }
 

--- a/source/php/BlockManager.php
+++ b/source/php/BlockManager.php
@@ -114,12 +114,12 @@
             $display = new Display();
             $postType = \Modularity\ModuleManager::prefixSlug($block['title']);
             $class = \Modularity\ModuleManager::$classes[$postType];
-            $module = new \Modularity\Module\Notice\Notice();
+            $module = new $class;
             $module->data = $block['data'];
-            
+            $view = str_replace('.blade.php', '', $module->template());
             //echo '<pre>', print_r($block['data']), '</pre>';
             $viewData = array_merge(['post_type' => $block['postType']], $module->data());
             
-            echo  $display->renderView($block['title'], $viewData);
+            echo  $display->renderView($view, $viewData);
         }
     }

--- a/source/php/BlockManager.php
+++ b/source/php/BlockManager.php
@@ -3,75 +3,107 @@
 
     class BlockManager {
 
-        private $postTypes = [];
+        public $modules = [];
 
-        public function __construct() {
+        public function __construct() {            
             add_filter( 'block_categories', array($this, 'filterCategories'), 10, 2 );
             add_filter('acf/load_field_group', array($this, 'addLocationRule'));
+            add_filter( 'allowed_block_types', array($this, 'filterBlockTypes') );
         }
 
-        
+        public function filterBlockTypes($allowedBlocks) {
+            $registeredBlocks = \WP_Block_Type_Registry::get_instance()->get_all_registered();
 
-        function filterCategories( $categories, $post ) {
+            foreach($registeredBlocks as $type => $block) {
+                if(str_contains($type, 'core/') && $type !== 'core/freeform') {
+                    unset($registeredBlocks[$type]);
+                }                
+            }
 
+            return array_keys($registeredBlocks);                        
+        }
+
+        /* public function getCategories($slugs) {
+            $categories = [];
+            foreach($slugs as $slug) {
+                $categorySlug = str_replace('mod-', '', $slug);
+                $categoryTitle = ucfirst(str_replace('-', ' ', $categorySlug));
+                $categories[] = [
+                    'slug' => $categorySlug,
+                    'title' => __( $categoryTitle, 'modularity' ),
+                    'icon' => 'wordpress'
+                ];
+            }
+
+            return $categories;
+        } */
+
+        public function filterCategories( $categories, $post ) {     
+            //$customCategories = $this->getCategories($this->modules);       
+            
             return array_merge(
                 $categories,
-                array(
-                    array(
-                        'slug' => 'modules',
-                        'title' => __( 'Modules', 'my-plugin' ),
-                        'icon'  => 'wordpress',
-                    ),
-                )
+                array([
+                    'slug' => 'modules',
+                    'title' => __( 'Modules', 'modularity' ),
+                    'icon' => 'wordpress'
+                ])
             );
         }
         
-
         public function registerBlock($name) {
+        $modules = ['slider', 'notice'];
+        
+            /* foreach ( $this->modules as $key => &$name) {
+                $name = str_replace('mod-', '', $name);               
+            } */
+
             // Register module as a block
             if( function_exists('acf_register_block_type') ) {
-        
-                acf_register_block_type(array(
-                    'name'              => $name,
-                    'title'             => __($name),
-                    'description'       => __('A custom testimonial block.'),
-                    'render_callback'   => array($this, 'renderBlock'),
-                    'category'          => 'modules',
-                ));
+                
+                    /* $moduleView = MODULARITY_PATH . 'source/php/Module/' . $name . '/views';
+                    if(!\file_exists($moduleView)) {
+                        continue;
+                    }
+                    $views = scandir($moduleView); */
+                                                            
+                    /* foreach($views as $view) {
+                        if(!str_contains($view, '.blade.php')) {
+                            continue;
+                        }
+                        $view = str_replace('.blade.php', '', $view); 
+    
+                    }   */ 
+                    
+                    
+                    acf_register_block_type(array(
+                        'name'              => $name,
+                        'title'             => __($name),
+                        'description'       => __('A custom testimonial block.'),
+                        'render_callback'   => array($this, 'renderBlock'),
+                        'category'          => 'modules',
+                        'postType'          => 'mod-' . $name
+                    ));
             }
+
         }
 
-        /* private function getModuleFieldGroupKey($postType) {
-            $groups = acf_get_field_groups(array('post_type' => $postType));
-            
-            return $groups;
-            foreach($groups as $group) {
-                foreach($group['location'] as $locationGroups) {
-                    foreach($locationGroups as $locationGroup) {
-                        if($locationGroup['value'] == $postType || $locationGroup['operator'] == '==') {
-                            return $group['key'];
-                        }                        
-                    }                    
-                }
-            }
-        } */
-
         public function addLocationRule($group) {
-            $enabledModules = \Modularity\ModuleManager::$enabled;
+            $enabledModules = \Modularity\ModuleManager::$enabled;            
             
             foreach($group['location'] as $location) {
                 foreach($location as $locationRule) {
                     $valueIsModule = in_array($locationRule['value'], $enabledModules);            
-                        if($valueIsModule && $locationRule['operator'] === '==') {
-                            $group['location'][] = [
-                                [
-                                    'param' => 'block',
-                                    'operator' => '==', 
-                                    'value' => \str_replace('mod-', 'acf/', $locationRule['value'])
-                                ]
-                            ];                            
-                        }
-                    
+                    if($valueIsModule && $locationRule['operator'] === '==') {
+                        $group['location'][] = [
+                            [
+                                'param' => 'block',
+                                'operator' => '==', 
+                                'value' => \str_replace('mod-', 'acf/', $locationRule['value'])
+                            ]
+                        ];  
+                        
+                    }                    
                 }
             }
 
@@ -81,13 +113,13 @@
         public function renderBlock($block) {
             $display = new Display();
             $postType = \Modularity\ModuleManager::prefixSlug($block['title']);
-            $this->postTypes[] = $postType;
             $class = \Modularity\ModuleManager::$classes[$postType];
             $module = new \Modularity\Module\Notice\Notice();
             $module->data = $block['data'];
-            $viewData = array_merge(['post_type' => $postType], $module->data());
+            
+            //echo '<pre>', print_r($block['data']), '</pre>';
+            $viewData = array_merge(['post_type' => $block['postType']], $module->data());
             
             echo  $display->renderView($block['title'], $viewData);
         }
-
     }

--- a/source/php/BlockManager.php
+++ b/source/php/BlockManager.php
@@ -1,0 +1,93 @@
+<?php
+    namespace Modularity;
+
+    class BlockManager {
+
+        private $postTypes = [];
+
+        public function __construct() {
+            add_filter( 'block_categories', array($this, 'filterCategories'), 10, 2 );
+            add_filter('acf/load_field_group', array($this, 'addLocationRule'));
+        }
+
+        
+
+        function filterCategories( $categories, $post ) {
+
+            return array_merge(
+                $categories,
+                array(
+                    array(
+                        'slug' => 'modules',
+                        'title' => __( 'Modules', 'my-plugin' ),
+                        'icon'  => 'wordpress',
+                    ),
+                )
+            );
+        }
+        
+
+        public function registerBlock($name) {
+            // Register module as a block
+            if( function_exists('acf_register_block_type') ) {
+        
+                acf_register_block_type(array(
+                    'name'              => $name,
+                    'title'             => __($name),
+                    'description'       => __('A custom testimonial block.'),
+                    'render_callback'   => array($this, 'renderBlock'),
+                    'category'          => 'modules',
+                ));
+            }
+        }
+
+        /* private function getModuleFieldGroupKey($postType) {
+            $groups = acf_get_field_groups(array('post_type' => $postType));
+            
+            return $groups;
+            foreach($groups as $group) {
+                foreach($group['location'] as $locationGroups) {
+                    foreach($locationGroups as $locationGroup) {
+                        if($locationGroup['value'] == $postType || $locationGroup['operator'] == '==') {
+                            return $group['key'];
+                        }                        
+                    }                    
+                }
+            }
+        } */
+
+        public function addLocationRule($group) {
+            $enabledModules = \Modularity\ModuleManager::$enabled;
+            
+            foreach($group['location'] as $location) {
+                foreach($location as $locationRule) {
+                    $valueIsModule = in_array($locationRule['value'], $enabledModules);            
+                        if($valueIsModule && $locationRule['operator'] === '==') {
+                            $group['location'][] = [
+                                [
+                                    'param' => 'block',
+                                    'operator' => '==', 
+                                    'value' => \str_replace('mod-', 'acf/', $locationRule['value'])
+                                ]
+                            ];                            
+                        }
+                    
+                }
+            }
+
+            return $group;
+        }
+
+        public function renderBlock($block) {
+            $display = new Display();
+            $postType = \Modularity\ModuleManager::prefixSlug($block['title']);
+            $this->postTypes[] = $postType;
+            $class = \Modularity\ModuleManager::$classes[$postType];
+            $module = new \Modularity\Module\Notice\Notice();
+            $module->data = $block['data'];
+            $viewData = array_merge(['post_type' => $postType], $module->data());
+            
+            echo  $display->renderView($block['title'], $viewData);
+        }
+
+    }

--- a/source/php/Module.php
+++ b/source/php/Module.php
@@ -84,6 +84,12 @@ class Module
     public $isDeprecated = false;
 
     /**
+     * Is the module deprecated?
+     * @var boolean
+     */
+    public $isGutenbergReady = false;
+
+    /**
      * Is this module a legacy module (not updated to new registration methods)
      * @var boolean
      */
@@ -346,6 +352,9 @@ class Module
         }
 
         add_action('Modularity/Init', function ($moduleManager) use ($slug, $nameSingular, $namePlural, $description, $supports, $icon, $plugin, $cache_ttl, $hideTitle) {
+            add_filter('acf/load_field_group', function() {
+                var_dump("FUCK");
+            });
             $module = new \Modularity\Module();
             $module->slug = $slug;
             $module->nameSingular = $nameSingular;

--- a/source/php/Module.php
+++ b/source/php/Module.php
@@ -84,7 +84,7 @@ class Module
     public $isDeprecated = false;
 
     /**
-     * Is the module deprecated?
+     * Will the module work as a block?
      * @var boolean
      */
     public $isBlockCompatible = true;
@@ -352,9 +352,6 @@ class Module
         }
 
         add_action('Modularity/Init', function ($moduleManager) use ($slug, $nameSingular, $namePlural, $description, $supports, $icon, $plugin, $cache_ttl, $hideTitle) {
-            add_filter('acf/load_field_group', function() {
-                var_dump("FUCK");
-            });
             $module = new \Modularity\Module();
             $module->slug = $slug;
             $module->nameSingular = $nameSingular;

--- a/source/php/Module.php
+++ b/source/php/Module.php
@@ -87,7 +87,7 @@ class Module
      * Is the module deprecated?
      * @var boolean
      */
-    public $isGutenbergReady = false;
+    public $isBlockCompatible = true;
 
     /**
      * Is this module a legacy module (not updated to new registration methods)

--- a/source/php/ModuleManager.php
+++ b/source/php/ModuleManager.php
@@ -2,6 +2,7 @@
 
 namespace Modularity;
 
+use BladeComponentLibrary\Init as CompLibInitator;
 class ModuleManager
 {
     /**
@@ -52,13 +53,16 @@ class ModuleManager
      */
     public static $widths = array();
 
+    public static $blockManager = null;
+
     public function __construct()
     {
+        self::$blockManager = new \Modularity\BlockManager();
 
         // Init modules
-        add_action('init', function () {
-
+        add_action('init', function () {            
             self::$enabled = self::getEnabled();
+            self::$blockManager->modules = self::$enabled;
             self::$registered = $this->getRegistered();
 
             $this->init();
@@ -92,7 +96,7 @@ class ModuleManager
 
         return apply_filters('Modularity/Modules', self::$registered);
     }
-
+    
     /**
      * Get enabled modules id:s
      * @return array
@@ -130,7 +134,7 @@ class ModuleManager
      */
     public function init()
     {
-        foreach (self::$registered as $path => $module) {
+        foreach (self::$registered as $path => $module) {            
             $path = trailingslashit($path);
             $source = $path . $module . '.php';
             $namespace = \Modularity\Helper\File::getNamespace($source);
@@ -145,7 +149,7 @@ class ModuleManager
 
             $this->register($class, $path);
         }
-
+        
         do_action('Modularity/Init', $this);
     }
 
@@ -167,6 +171,10 @@ class ModuleManager
 
         // Get post type slug
         $postTypeSlug = self::prefixSlug($class->slug);
+
+        self::$blockManager->registerBlock($class->slug);
+        
+        
         self::$classes[$postTypeSlug] = $class;
 
         // Set labels

--- a/source/php/ModuleManager.php
+++ b/source/php/ModuleManager.php
@@ -171,11 +171,7 @@ class ModuleManager
             return;
         }
 
-        // Get post type slug
-        $postTypeSlug = self::prefixSlug($class->slug);
-
-        
-    
+        $postTypeSlug = self::prefixSlug($class->slug);    
         self::$classes[$postTypeSlug] = $class;
 
         // Set labels

--- a/source/php/ModuleManager.php
+++ b/source/php/ModuleManager.php
@@ -61,8 +61,7 @@ class ModuleManager
 
         // Init modules
         add_action('init', function () {            
-            self::$enabled = self::getEnabled();
-            self::$blockManager->modules = self::$enabled;
+            self::$enabled = self::getEnabled();        
             self::$registered = $this->getRegistered();
 
             $this->init();
@@ -146,10 +145,13 @@ class ModuleManager
             require_once $source;
             $class = $namespace . '\\' . $module;
             $class = new $class();
-
+            
             $this->register($class, $path);
+            self::$blockManager->classes[$class->slug] = $class;
         }
-        
+
+        self::$blockManager->registerBlocks();
+
         do_action('Modularity/Init', $this);
     }
 
@@ -172,9 +174,8 @@ class ModuleManager
         // Get post type slug
         $postTypeSlug = self::prefixSlug($class->slug);
 
-        self::$blockManager->registerBlock($class->slug);
         
-        
+    
         self::$classes[$postTypeSlug] = $class;
 
         // Set labels


### PR DESCRIPTION
Implement modules as blocks

- Add a new class that handles the registrering of modules as blocks
- Filter out all of the native blocks except the classic editor
- Add a new block category called Modules
- Add a location rule to all field groups that belongs to the a module, to allow them to be shown on corresponding block type
- Check if module is set as isBlockCompatible before registering 