### PR TITLE
bail if post type query var is not set to Any

### DIFF
--- a/source/php/Search.php
+++ b/source/php/Search.php
@@ -31,7 +31,9 @@ class Search
         global $wp_query;
 
         //Only run on search
-        if (!$wp_query->is_search() || is_admin()) {
+        if (!$wp_query->is_search()
+            || is_admin()
+            || $wp_query->query_vars['post_type'] !== 'any') {
             return;
         }
 


### PR DESCRIPTION
Bail module search filter so it runs only on search queries where post type is set to "any".
Because when it runs on other archives it fucks up the search and also breaks pagination. 