### PR TITLE
Temporary validation for required fields in blocks

### DIFF
--- a/modularity.php
+++ b/modularity.php
@@ -80,6 +80,7 @@ add_action('plugins_loaded', function () {
         'mod-social'           => 'group_56dedc26e5327',
         'mod-wpwidget'         => 'group_5729f4d3e7c7a',
         'mod-sites'            => 'group_58ecb6b6330f4',
+        'mod-table-block'      => 'group_60b8bf5bbc4d7'
 
     ));
     $acfExportManager->import();

--- a/source/php/AcfFields/json/mod-contacts.json
+++ b/source/php/AcfFields/json/mod-contacts.json
@@ -20,7 +20,9 @@
                 "vertical": "Horisontella kort",
                 "list": "Lista"
             },
-            "default_value": "cards",
+            "default_value": [
+                "cards"
+            ],
             "allow_null": 0,
             "multiple": 0,
             "ui": 0,
@@ -202,7 +204,9 @@
                                         "phone": "Fasttelefon",
                                         "smartphone": "Mobil"
                                     },
-                                    "default_value": "phone",
+                                    "default_value": [
+                                        "phone"
+                                    ],
                                     "allow_null": 0,
                                     "multiple": 0,
                                     "ui": 0,
@@ -269,7 +273,9 @@
                                         "twitter": "Twitter",
                                         "instagram": "Instagram"
                                     },
-                                    "default_value": "facebook",
+                                    "default_value": [
+                                        "facebook"
+                                    ],
                                     "allow_null": 0,
                                     "multiple": 0,
                                     "ui": 0,
@@ -442,7 +448,9 @@
                 "grid-md-4": "3",
                 "grid-md-3": "4"
             },
-            "default_value": "grid-md-12",
+            "default_value": [
+                "grid-md-12"
+            ],
             "allow_null": 0,
             "multiple": 0,
             "ui": 0,
@@ -484,6 +492,13 @@
                 "param": "post_type",
                 "operator": "==",
                 "value": "mod-contacts"
+            }
+        ],
+        [
+            {
+                "param": "block",
+                "operator": "==",
+                "value": "acf\/contacts"
             }
         ]
     ],

--- a/source/php/AcfFields/json/mod-table-block.json
+++ b/source/php/AcfFields/json/mod-table-block.json
@@ -9,7 +9,7 @@
                 "name": "mod_table_data_type",
                 "type": "radio",
                 "instructions": "",
-                "required": 1,
+                "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
                     "width": "",
@@ -22,7 +22,7 @@
                 },
                 "allow_null": 0,
                 "other_choice": 0,
-                "default_value": "",
+                "default_value": "manual",
                 "layout": "horizontal",
                 "return_format": "value",
                 "save_other_choice": 0
@@ -87,7 +87,7 @@
                 "name": "mod_table",
                 "type": "table",
                 "instructions": "",
-                "required": 0,
+                "required": 1,
                 "conditional_logic": [
                     [
                         {

--- a/source/php/AcfFields/json/mod-table-block.json
+++ b/source/php/AcfFields/json/mod-table-block.json
@@ -1,240 +1,239 @@
-[
-    {
-        "key": "group_60b8bf5bbc4d7",
-        "title": "Table - Block settings",
-        "fields": [
-            {
-                "key": "field_60b8c0d61b71e",
-                "label": "Datatyp",
-                "name": "mod_table_data_type",
-                "type": "radio",
-                "instructions": "",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "choices": {
-                    "manual": "Manual input",
-                    "csv": "CSV Import"
-                },
-                "allow_null": 0,
-                "other_choice": 0,
-                "default_value": "manual",
-                "layout": "horizontal",
-                "return_format": "value",
-                "save_other_choice": 0
+[{
+    "key": "group_60b8bf5bbc4d7",
+    "title": "Table - Block settings",
+    "fields": [
+        {
+            "key": "field_60b8c0d61b71e",
+            "label": "Datatyp",
+            "name": "mod_table_data_type",
+            "type": "radio",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
             },
-            {
-                "key": "field_60b9dd6efc445",
-                "label": "CSV-fil",
-                "name": "mod_table_block_csv_file",
-                "type": "file",
-                "instructions": "CSV-formatterad fil",
-                "required": 1,
-                "conditional_logic": [
-                    [
-                        {
-                            "field": "field_60b8c0d61b71e",
-                            "operator": "==",
-                            "value": "csv"
-                        }
-                    ]
-                ],
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "return_format": "array",
-                "library": "all",
-                "min_size": "",
-                "max_size": "",
-                "mime_types": ".csv"
+            "choices": {
+                "manual": "Manual input",
+                "csv": "CSV Import"
             },
-            {
-                "key": "field_60b9dc81fc444",
-                "label": "CSV-avgränsare",
-                "name": "mod_table_csv_delimiter",
-                "type": "text",
-                "instructions": "Tecken som används i CSV-filen som avgränsare. Brukar vara kommatecken eller semikolon.",
-                "required": 1,
-                "conditional_logic": [
-                    [
-                        {
-                            "field": "field_60b8c0d61b71e",
-                            "operator": "==",
-                            "value": "csv"
-                        }
-                    ]
-                ],
-                "wrapper": {
-                    "width": "50",
-                    "class": "",
-                    "id": ""
-                },
-                "default_value": ";",
-                "placeholder": "",
-                "prepend": "",
-                "append": "",
-                "maxlength": ""
+            "allow_null": 0,
+            "other_choice": 0,
+            "default_value": "manual",
+            "layout": "horizontal",
+            "return_format": "value",
+            "save_other_choice": 0
+        },
+        {
+            "key": "field_60b9dd6efc445",
+            "label": "CSV-fil",
+            "name": "mod_table_block_csv_file",
+            "type": "file",
+            "instructions": "CSV-formatterad fil",
+            "required": 1,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_60b8c0d61b71e",
+                        "operator": "==",
+                        "value": "csv"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
             },
-            {
-                "key": "field_60b8c09f1b71d",
-                "label": "Table",
-                "name": "mod_table",
-                "type": "table",
-                "instructions": "",
-                "required": 1,
-                "conditional_logic": [
-                    [
-                        {
-                            "field": "field_60b8c0d61b71e",
-                            "operator": "==",
-                            "value": "manual"
-                        }
-                    ]
-                ],
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "use_header": 0,
-                "use_caption": 2
+            "return_format": "array",
+            "library": "all",
+            "min_size": "",
+            "max_size": "",
+            "mime_types": ".csv"
+        },
+        {
+            "key": "field_60b9dc81fc444",
+            "label": "CSV-avgr\u00e4nsare",
+            "name": "mod_table_csv_delimiter",
+            "type": "text",
+            "instructions": "Tecken som anv\u00e4nds i CSV-filen som avgr\u00e4nsare. Brukar vara kommatecken eller semikolon.",
+            "required": 1,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_60b8c0d61b71e",
+                        "operator": "==",
+                        "value": "csv"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "50",
+                "class": "",
+                "id": ""
             },
-            {
-                "key": "field_60b9def7b1bf4",
-                "label": "Sidbläddring",
-                "name": "mod_table_pagination",
-                "type": "true_false",
-                "instructions": "",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "50",
-                    "class": "",
-                    "id": ""
-                },
-                "message": "Yes, use pagination on this table",
-                "default_value": 1,
-                "ui": 0,
-                "ui_on_text": "",
-                "ui_off_text": ""
+            "default_value": ";",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_60b8c09f1b71d",
+            "label": "Table",
+            "name": "mod_table",
+            "type": "table",
+            "instructions": "",
+            "required": 1,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_60b8c0d61b71e",
+                        "operator": "==",
+                        "value": "manual"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
             },
-            {
-                "key": "field_60b9df3d7f217",
-                "label": "Antal inlägg\/sidor",
-                "name": "mod_table_pagination_count",
-                "type": "number",
-                "instructions": "",
-                "required": 0,
-                "conditional_logic": [
-                    [
-                        {
-                            "field": "field_60b9def7b1bf4",
-                            "operator": "==",
-                            "value": "1"
-                        }
-                    ]
-                ],
-                "wrapper": {
-                    "width": "50",
-                    "class": "",
-                    "id": ""
-                },
-                "default_value": 10,
-                "placeholder": "",
-                "prepend": "",
-                "append": "",
-                "min": 1,
-                "max": 500,
-                "step": ""
+            "use_header": 0,
+            "use_caption": 2
+        },
+        {
+            "key": "field_60b9def7b1bf4",
+            "label": "Sidbl\u00e4ddring",
+            "name": "mod_table_pagination",
+            "type": "true_false",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "50",
+                "class": "",
+                "id": ""
             },
-            {
-                "key": "field_60b9df727f218",
-                "label": "Aktivera sök",
-                "name": "mod_table_search",
-                "type": "true_false",
-                "instructions": "",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "50",
-                    "class": "",
-                    "id": ""
-                },
-                "message": "",
-                "default_value": 1,
-                "ui": 0,
-                "ui_on_text": "",
-                "ui_off_text": ""
+            "message": "Yes, use pagination on this table",
+            "default_value": 1,
+            "ui": 0,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        },
+        {
+            "key": "field_60b9df3d7f217",
+            "label": "Antal inl\u00e4gg\/sidor",
+            "name": "mod_table_pagination_count",
+            "type": "number",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_60b9def7b1bf4",
+                        "operator": "==",
+                        "value": "1"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "50",
+                "class": "",
+                "id": ""
             },
-            {
-                "key": "field_60b9df987f219",
-                "label": "Sökfras",
-                "name": "mod_table_search_query",
-                "type": "text",
-                "instructions": "",
-                "required": 0,
-                "conditional_logic": [
-                    [
-                        {
-                            "field": "field_60b9df727f218",
-                            "operator": "==",
-                            "value": "1"
-                        }
-                    ]
-                ],
-                "wrapper": {
-                    "width": "50",
-                    "class": "",
-                    "id": ""
-                },
-                "default_value": "Search in list",
-                "placeholder": "",
-                "prepend": "",
-                "append": "",
-                "maxlength": ""
+            "default_value": 10,
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "min": 1,
+            "max": 500,
+            "step": ""
+        },
+        {
+            "key": "field_60b9df727f218",
+            "label": "Aktivera s\u00f6k",
+            "name": "mod_table_search",
+            "type": "true_false",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "50",
+                "class": "",
+                "id": ""
             },
+            "message": "",
+            "default_value": 1,
+            "ui": 0,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        },
+        {
+            "key": "field_60b9df987f219",
+            "label": "S\u00f6kfras",
+            "name": "mod_table_search_query",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_60b9df727f218",
+                        "operator": "==",
+                        "value": "1"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "50",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "Search in list",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_60b9dfdf490d9",
+            "label": "Aktivera kolumnsortering",
+            "name": "mod_table_ordering",
+            "type": "true_false",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "Yes, enable column sorting",
+            "default_value": 1,
+            "ui": 0,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        }
+    ],
+    "location": [
+        [
             {
-                "key": "field_60b9dfdf490d9",
-                "label": "Aktivera kolumnsortering",
-                "name": "mod_table_ordering",
-                "type": "true_false",
-                "instructions": "",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "message": "Yes, enable column sorting",
-                "default_value": 1,
-                "ui": 0,
-                "ui_on_text": "",
-                "ui_off_text": ""
+                "param": "block",
+                "operator": "==",
+                "value": "acf\/table"
             }
-        ],
-        "location": [
-            [
-                {
-                    "param": "block",
-                    "operator": "==",
-                    "value": "acf\/table"
-                }
-            ]
-        ],
-        "menu_order": 0,
-        "position": "normal",
-        "style": "default",
-        "label_placement": "top",
-        "instruction_placement": "label",
-        "hide_on_screen": "",
-        "active": true,
-        "description": ""
-    }
-]
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": ""
+}]
+

--- a/source/php/AcfFields/php/mod-contacts.php
+++ b/source/php/AcfFields/php/mod-contacts.php
@@ -3,7 +3,7 @@
 if (function_exists('acf_add_local_field_group')) {
     acf_add_local_field_group(array(
     'key' => 'group_5805e5dc0a3be',
-    'title' => 'Contacts',
+    'title' => __('Contacts', 'modularity'),
     'fields' => array(
         0 => array(
             'key' => 'field_5805e5dc1da44',
@@ -23,7 +23,9 @@
                 'vertical' => __('Horisontella kort', 'modularity'),
                 'list' => __('Lista', 'modularity'),
             ),
-            'default_value' => 'cards',
+            'default_value' => array(
+                0 => __('cards', 'modularity'),
+            ),
             'allow_null' => 0,
             'multiple' => 0,
             'ui' => 0,
@@ -53,7 +55,7 @@
                     'sub_fields' => array(
                         0 => array(
                             'key' => 'field_5805e5dc26dde',
-                            'label' => __('Bild', 'modularity'),
+                            'label' => 'Bild',
                             'name' => 'image',
                             'type' => 'image',
                             'instructions' => '',
@@ -77,7 +79,7 @@
                         ),
                         1 => array(
                             'key' => 'field_5805e5dc27255',
-                            'label' => __('First name or location', 'modularity'),
+                            'label' => 'First name or location',
                             'name' => 'first_name',
                             'type' => 'text',
                             'instructions' => '',
@@ -96,7 +98,7 @@
                         ),
                         2 => array(
                             'key' => 'field_5805e5dc276e1',
-                            'label' => __('Efternamn', 'modularity'),
+                            'label' => 'Efternamn',
                             'name' => 'last_name',
                             'type' => 'text',
                             'instructions' => '',
@@ -115,7 +117,7 @@
                         ),
                         3 => array(
                             'key' => 'field_5805e5dc2771c',
-                            'label' => __('Jobbtitel', 'modularity'),
+                            'label' => 'Jobbtitel',
                             'name' => 'work_title',
                             'type' => 'text',
                             'instructions' => '',
@@ -134,7 +136,7 @@
                         ),
                         4 => array(
                             'key' => 'field_5805e5dc277e3',
-                            'label' => __('Förvaltning', 'modularity'),
+                            'label' => 'Förvaltning',
                             'name' => 'administration_unit',
                             'type' => 'text',
                             'instructions' => '',
@@ -153,7 +155,7 @@
                         ),
                         5 => array(
                             'key' => 'field_5805e5dc27b58',
-                            'label' => __('E-mail', 'modularity'),
+                            'label' => 'E-mail',
                             'name' => 'email',
                             'type' => 'email',
                             'instructions' => '',
@@ -171,7 +173,7 @@
                         ),
                         6 => array(
                             'key' => 'field_5805e62f94d0f',
-                            'label' => __('Telefon', 'modularity'),
+                            'label' => 'Telefon',
                             'name' => 'phone_numbers',
                             'type' => 'repeater',
                             'instructions' => '',
@@ -186,11 +188,11 @@
                             'min' => 0,
                             'max' => 0,
                             'layout' => 'table',
-                            'button_label' => __('Lägg till nummer', 'modularity'),
+                            'button_label' => 'Lägg till nummer',
                             'sub_fields' => array(
                                 0 => array(
                                     'key' => 'field_5bf6aa828136b',
-                                    'label' => __('Typ', 'modularity'),
+                                    'label' => 'Typ',
                                     'name' => 'type',
                                     'type' => 'select',
                                     'instructions' => '',
@@ -202,10 +204,12 @@
                                         'id' => '',
                                     ),
                                     'choices' => array(
-                                        'phone' => __('Fasttelefon', 'modularity'),
-                                        'smartphone' => __('Mobil', 'modularity'),
+                                        'phone' => 'Fasttelefon',
+                                        'smartphone' => 'Mobil',
                                     ),
-                                    'default_value' => 'phone',
+                                    'default_value' => array(
+                                        0 => 'phone',
+                                    ),
                                     'allow_null' => 0,
                                     'multiple' => 0,
                                     'ui' => 0,
@@ -215,7 +219,7 @@
                                 ),
                                 1 => array(
                                     'key' => 'field_5805e64a94d10',
-                                    'label' => __('Telefonnummer', 'modularity'),
+                                    'label' => 'Telefonnummer',
                                     'name' => 'number',
                                     'type' => 'text',
                                     'instructions' => '',
@@ -236,7 +240,7 @@
                         ),
                         7 => array(
                             'key' => 'field_5bf6a5fbc1b6b',
-                            'label' => __('Social Media', 'modularity'),
+                            'label' => 'Social Media',
                             'name' => 'social_media',
                             'type' => 'repeater',
                             'instructions' => '',
@@ -255,7 +259,7 @@
                             'sub_fields' => array(
                                 0 => array(
                                     'key' => 'field_5bf6a737c1b6c',
-                                    'label' => __('Media', 'modularity'),
+                                    'label' => 'Media',
                                     'name' => 'media',
                                     'type' => 'select',
                                     'instructions' => '',
@@ -267,12 +271,14 @@
                                         'id' => '',
                                     ),
                                     'choices' => array(
-                                        'facebook' => __('Facebook', 'modularity'),
-                                        'linkedin' => __('LinkedIn', 'modularity'),
-                                        'twitter' => __('Twitter', 'modularity'),
-                                        'instagram' => __('Instagram', 'modularity'),
+                                        'facebook' => 'Facebook',
+                                        'linkedin' => 'LinkedIn',
+                                        'twitter' => 'Twitter',
+                                        'instagram' => 'Instagram',
                                     ),
-                                    'default_value' => 'facebook',
+                                    'default_value' => array(
+                                        0 => 'facebook',
+                                    ),
                                     'allow_null' => 0,
                                     'multiple' => 0,
                                     'ui' => 0,
@@ -282,7 +288,7 @@
                                 ),
                                 1 => array(
                                     'key' => 'field_5bf6a991c1b6d',
-                                    'label' => __('URL', 'modularity'),
+                                    'label' => 'URL',
                                     'name' => 'url',
                                     'type' => 'url',
                                     'instructions' => '',
@@ -300,7 +306,7 @@
                         ),
                         8 => array(
                             'key' => 'field_5805e5dc28d3a',
-                            'label' => __('Address', 'modularity'),
+                            'label' => 'Address',
                             'name' => 'address',
                             'type' => 'textarea',
                             'instructions' => '',
@@ -319,7 +325,7 @@
                         ),
                         9 => array(
                             'key' => 'field_5805e5dc28e30',
-                            'label' => __('Besöksadress', 'modularity'),
+                            'label' => 'Besöksadress',
                             'name' => 'visiting_address',
                             'type' => 'textarea',
                             'instructions' => '',
@@ -338,7 +344,7 @@
                         ),
                         10 => array(
                             'key' => 'field_5805e5dc29114',
-                            'label' => __('Öppettider', 'modularity'),
+                            'label' => 'Öppettider',
                             'name' => 'opening_hours',
                             'type' => 'textarea',
                             'instructions' => '',
@@ -357,7 +363,7 @@
                         ),
                         11 => array(
                             'key' => 'field_5805e5dc29182',
-                            'label' => __('Annat', 'modularity'),
+                            'label' => 'Annat',
                             'name' => 'other',
                             'type' => 'wysiwyg',
                             'instructions' => '',
@@ -386,7 +392,7 @@
                     'sub_fields' => array(
                         0 => array(
                             'key' => 'field_5805e5dc291c4',
-                            'label' => __('Välj användare', 'modularity'),
+                            'label' => 'Välj användare',
                             'name' => 'user',
                             'type' => 'user',
                             'instructions' => '',
@@ -445,7 +451,9 @@
                 'grid-md-4' => __('3', 'modularity'),
                 'grid-md-3' => __('4', 'modularity'),
             ),
-            'default_value' => 'grid-md-12',
+            'default_value' => array(
+                0 => __('grid-md-12', 'modularity'),
+            ),
             'allow_null' => 0,
             'multiple' => 0,
             'ui' => 0,
@@ -487,6 +495,13 @@
                 'param' => 'post_type',
                 'operator' => '==',
                 'value' => 'mod-contacts',
+            ),
+        ),
+        1 => array(
+            0 => array(
+                'param' => 'block',
+                'operator' => '==',
+                'value' => 'acf/contacts',
             ),
         ),
     ),

--- a/source/php/AcfFields/php/mod-contacts.php
+++ b/source/php/AcfFields/php/mod-contacts.php
@@ -3,7 +3,7 @@
 if (function_exists('acf_add_local_field_group')) {
     acf_add_local_field_group(array(
     'key' => 'group_5805e5dc0a3be',
-    'title' => __('Contacts', 'modularity'),
+    'title' => 'Contacts',
     'fields' => array(
         0 => array(
             'key' => 'field_5805e5dc1da44',
@@ -55,7 +55,7 @@
                     'sub_fields' => array(
                         0 => array(
                             'key' => 'field_5805e5dc26dde',
-                            'label' => 'Bild',
+                            'label' => __('Bild', 'modularity'),
                             'name' => 'image',
                             'type' => 'image',
                             'instructions' => '',
@@ -79,7 +79,7 @@
                         ),
                         1 => array(
                             'key' => 'field_5805e5dc27255',
-                            'label' => 'First name or location',
+                            'label' => __('First name or location', 'modularity'),
                             'name' => 'first_name',
                             'type' => 'text',
                             'instructions' => '',
@@ -98,7 +98,7 @@
                         ),
                         2 => array(
                             'key' => 'field_5805e5dc276e1',
-                            'label' => 'Efternamn',
+                            'label' => __('Efternamn', 'modularity'),
                             'name' => 'last_name',
                             'type' => 'text',
                             'instructions' => '',
@@ -117,7 +117,7 @@
                         ),
                         3 => array(
                             'key' => 'field_5805e5dc2771c',
-                            'label' => 'Jobbtitel',
+                            'label' => __('Jobbtitel', 'modularity'),
                             'name' => 'work_title',
                             'type' => 'text',
                             'instructions' => '',
@@ -136,7 +136,7 @@
                         ),
                         4 => array(
                             'key' => 'field_5805e5dc277e3',
-                            'label' => 'Förvaltning',
+                            'label' => __('Förvaltning', 'modularity'),
                             'name' => 'administration_unit',
                             'type' => 'text',
                             'instructions' => '',
@@ -155,7 +155,7 @@
                         ),
                         5 => array(
                             'key' => 'field_5805e5dc27b58',
-                            'label' => 'E-mail',
+                            'label' => __('E-mail', 'modularity'),
                             'name' => 'email',
                             'type' => 'email',
                             'instructions' => '',
@@ -173,7 +173,7 @@
                         ),
                         6 => array(
                             'key' => 'field_5805e62f94d0f',
-                            'label' => 'Telefon',
+                            'label' => __('Telefon', 'modularity'),
                             'name' => 'phone_numbers',
                             'type' => 'repeater',
                             'instructions' => '',
@@ -188,11 +188,11 @@
                             'min' => 0,
                             'max' => 0,
                             'layout' => 'table',
-                            'button_label' => 'Lägg till nummer',
+                            'button_label' => __('Lägg till nummer', 'modularity'),
                             'sub_fields' => array(
                                 0 => array(
                                     'key' => 'field_5bf6aa828136b',
-                                    'label' => 'Typ',
+                                    'label' => __('Typ', 'modularity'),
                                     'name' => 'type',
                                     'type' => 'select',
                                     'instructions' => '',
@@ -204,11 +204,11 @@
                                         'id' => '',
                                     ),
                                     'choices' => array(
-                                        'phone' => 'Fasttelefon',
-                                        'smartphone' => 'Mobil',
+                                        'phone' => __('Fasttelefon', 'modularity'),
+                                        'smartphone' => __('Mobil', 'modularity'),
                                     ),
                                     'default_value' => array(
-                                        0 => 'phone',
+                                        0 => __('phone', 'modularity'),
                                     ),
                                     'allow_null' => 0,
                                     'multiple' => 0,
@@ -219,7 +219,7 @@
                                 ),
                                 1 => array(
                                     'key' => 'field_5805e64a94d10',
-                                    'label' => 'Telefonnummer',
+                                    'label' => __('Telefonnummer', 'modularity'),
                                     'name' => 'number',
                                     'type' => 'text',
                                     'instructions' => '',
@@ -240,7 +240,7 @@
                         ),
                         7 => array(
                             'key' => 'field_5bf6a5fbc1b6b',
-                            'label' => 'Social Media',
+                            'label' => __('Social Media', 'modularity'),
                             'name' => 'social_media',
                             'type' => 'repeater',
                             'instructions' => '',
@@ -259,7 +259,7 @@
                             'sub_fields' => array(
                                 0 => array(
                                     'key' => 'field_5bf6a737c1b6c',
-                                    'label' => 'Media',
+                                    'label' => __('Media', 'modularity'),
                                     'name' => 'media',
                                     'type' => 'select',
                                     'instructions' => '',
@@ -271,13 +271,13 @@
                                         'id' => '',
                                     ),
                                     'choices' => array(
-                                        'facebook' => 'Facebook',
-                                        'linkedin' => 'LinkedIn',
-                                        'twitter' => 'Twitter',
-                                        'instagram' => 'Instagram',
+                                        'facebook' => __('Facebook', 'modularity'),
+                                        'linkedin' => __('LinkedIn', 'modularity'),
+                                        'twitter' => __('Twitter', 'modularity'),
+                                        'instagram' => __('Instagram', 'modularity'),
                                     ),
                                     'default_value' => array(
-                                        0 => 'facebook',
+                                        0 => __('facebook', 'modularity'),
                                     ),
                                     'allow_null' => 0,
                                     'multiple' => 0,
@@ -288,7 +288,7 @@
                                 ),
                                 1 => array(
                                     'key' => 'field_5bf6a991c1b6d',
-                                    'label' => 'URL',
+                                    'label' => __('URL', 'modularity'),
                                     'name' => 'url',
                                     'type' => 'url',
                                     'instructions' => '',
@@ -306,7 +306,7 @@
                         ),
                         8 => array(
                             'key' => 'field_5805e5dc28d3a',
-                            'label' => 'Address',
+                            'label' => __('Address', 'modularity'),
                             'name' => 'address',
                             'type' => 'textarea',
                             'instructions' => '',
@@ -325,7 +325,7 @@
                         ),
                         9 => array(
                             'key' => 'field_5805e5dc28e30',
-                            'label' => 'Besöksadress',
+                            'label' => __('Besöksadress', 'modularity'),
                             'name' => 'visiting_address',
                             'type' => 'textarea',
                             'instructions' => '',
@@ -344,7 +344,7 @@
                         ),
                         10 => array(
                             'key' => 'field_5805e5dc29114',
-                            'label' => 'Öppettider',
+                            'label' => __('Öppettider', 'modularity'),
                             'name' => 'opening_hours',
                             'type' => 'textarea',
                             'instructions' => '',
@@ -363,7 +363,7 @@
                         ),
                         11 => array(
                             'key' => 'field_5805e5dc29182',
-                            'label' => 'Annat',
+                            'label' => __('Annat', 'modularity'),
                             'name' => 'other',
                             'type' => 'wysiwyg',
                             'instructions' => '',
@@ -392,7 +392,7 @@
                     'sub_fields' => array(
                         0 => array(
                             'key' => 'field_5805e5dc291c4',
-                            'label' => 'Välj användare',
+                            'label' => __('Välj användare', 'modularity'),
                             'name' => 'user',
                             'type' => 'user',
                             'instructions' => '',

--- a/source/php/AcfFields/php/mod-table-block.php
+++ b/source/php/AcfFields/php/mod-table-block.php
@@ -1,244 +1,242 @@
-<?php
+<?php 
 
-if( function_exists('acf_add_local_field_group') ):
-
-    acf_add_local_field_group(array(
-        'key' => 'group_60b8bf5bbc4d7',
-        'title' => 'Table - Block settings',
-        'fields' => array(
-            array(
-                'key' => 'field_60b8c0d61b71e',
-                'label' => 'Datatyp',
-                'name' => 'mod_table_data_type',
-                'type' => 'radio',
-                'instructions' => '',
-                'required' => 0,
-                'conditional_logic' => 0,
-                'wrapper' => array(
-                    'width' => '',
-                    'class' => '',
-                    'id' => '',
-                ),
-                'choices' => array(
-                    'manual' => 'Manual input',
-                    'csv' => 'CSV Import',
-                ),
-                'allow_null' => 0,
-                'other_choice' => 0,
-                'default_value' => 'manual',
-                'layout' => 'horizontal',
-                'return_format' => 'value',
-                'save_other_choice' => 0,
+if (function_exists('acf_add_local_field_group')) {
+    acf_add_local_field_group(array(
+    'key' => 'group_60b8bf5bbc4d7',
+    'title' => 'Table - Block settings',
+    'fields' => array(
+        0 => array(
+            'key' => 'field_60b8c0d61b71e',
+            'label' => __('Datatyp', 'modularity'),
+            'name' => 'mod_table_data_type',
+            'type' => 'radio',
+            'instructions' => '',
+            'required' => 0,
+            'conditional_logic' => 0,
+            'wrapper' => array(
+                'width' => '',
+                'class' => '',
+                'id' => '',
             ),
-            array(
-                'key' => 'field_60b9dd6efc445',
-                'label' => 'CSV-fil',
-                'name' => 'mod_table_block_csv_file',
-                'type' => 'file',
-                'instructions' => 'CSV-formatterad fil',
-                'required' => 1,
-                'conditional_logic' => array(
-                    array(
-                        array(
-                            'field' => 'field_60b8c0d61b71e',
-                            'operator' => '==',
-                            'value' => 'csv',
-                        ),
+            'choices' => array(
+                'manual' => __('Manual input', 'modularity'),
+                'csv' => __('CSV Import', 'modularity'),
+            ),
+            'allow_null' => 0,
+            'other_choice' => 0,
+            'default_value' => __('manual', 'modularity'),
+            'layout' => 'horizontal',
+            'return_format' => 'value',
+            'save_other_choice' => 0,
+        ),
+        1 => array(
+            'key' => 'field_60b9dd6efc445',
+            'label' => __('CSV-fil', 'modularity'),
+            'name' => 'mod_table_block_csv_file',
+            'type' => 'file',
+            'instructions' => __('CSV-formatterad fil', 'modularity'),
+            'required' => 1,
+            'conditional_logic' => array(
+                0 => array(
+                    0 => array(
+                        'field' => 'field_60b8c0d61b71e',
+                        'operator' => '==',
+                        'value' => 'csv',
                     ),
                 ),
-                'wrapper' => array(
-                    'width' => '',
-                    'class' => '',
-                    'id' => '',
-                ),
-                'return_format' => 'array',
-                'library' => 'all',
-                'min_size' => '',
-                'max_size' => '',
-                'mime_types' => '.csv',
             ),
-            array(
-                'key' => 'field_60b9dc81fc444',
-                'label' => 'CSV-avgränsare',
-                'name' => 'mod_table_csv_delimiter',
-                'type' => 'text',
-                'instructions' => 'Tecken som används i CSV-filen som avgränsare. Brukar vara kommatecken eller semikolon.',
-                'required' => 1,
-                'conditional_logic' => array(
-                    array(
-                        array(
-                            'field' => 'field_60b8c0d61b71e',
-                            'operator' => '==',
-                            'value' => 'csv',
-                        ),
+            'wrapper' => array(
+                'width' => '',
+                'class' => '',
+                'id' => '',
+            ),
+            'return_format' => 'array',
+            'library' => 'all',
+            'min_size' => '',
+            'max_size' => '',
+            'mime_types' => '.csv',
+        ),
+        2 => array(
+            'key' => 'field_60b9dc81fc444',
+            'label' => __('CSV-avgränsare', 'modularity'),
+            'name' => 'mod_table_csv_delimiter',
+            'type' => 'text',
+            'instructions' => __('Tecken som används i CSV-filen som avgränsare. Brukar vara kommatecken eller semikolon.', 'modularity'),
+            'required' => 1,
+            'conditional_logic' => array(
+                0 => array(
+                    0 => array(
+                        'field' => 'field_60b8c0d61b71e',
+                        'operator' => '==',
+                        'value' => 'csv',
                     ),
                 ),
-                'wrapper' => array(
-                    'width' => '50',
-                    'class' => '',
-                    'id' => '',
-                ),
-                'default_value' => ';',
-                'placeholder' => '',
-                'prepend' => '',
-                'append' => '',
-                'maxlength' => '',
             ),
-            array(
-                'key' => 'field_60b8c09f1b71d',
-                'label' => 'Table',
-                'name' => 'mod_table',
-                'type' => 'table',
-                'instructions' => '',
-                'required' => 1,
-                'conditional_logic' => array(
-                    array(
-                        array(
-                            'field' => 'field_60b8c0d61b71e',
-                            'operator' => '==',
-                            'value' => 'manual',
-                        ),
+            'wrapper' => array(
+                'width' => '50',
+                'class' => '',
+                'id' => '',
+            ),
+            'default_value' => __(';', 'modularity'),
+            'placeholder' => '',
+            'prepend' => '',
+            'append' => '',
+            'maxlength' => '',
+        ),
+        3 => array(
+            'key' => 'field_60b8c09f1b71d',
+            'label' => __('Table', 'modularity'),
+            'name' => 'mod_table',
+            'type' => 'table',
+            'instructions' => '',
+            'required' => 1,
+            'conditional_logic' => array(
+                0 => array(
+                    0 => array(
+                        'field' => 'field_60b8c0d61b71e',
+                        'operator' => '==',
+                        'value' => 'manual',
                     ),
                 ),
-                'wrapper' => array(
-                    'width' => '',
-                    'class' => '',
-                    'id' => '',
-                ),
-                'use_header' => 0,
-                'use_caption' => 2,
             ),
-            array(
-                'key' => 'field_60b9def7b1bf4',
-                'label' => 'Sidbläddring',
-                'name' => 'mod_table_pagination',
-                'type' => 'true_false',
-                'instructions' => '',
-                'required' => 0,
-                'conditional_logic' => 0,
-                'wrapper' => array(
-                    'width' => '50',
-                    'class' => '',
-                    'id' => '',
-                ),
-                'message' => 'Yes, use pagination on this table',
-                'default_value' => 1,
-                'ui' => 0,
-                'ui_on_text' => '',
-                'ui_off_text' => '',
+            'wrapper' => array(
+                'width' => '',
+                'class' => '',
+                'id' => '',
             ),
-            array(
-                'key' => 'field_60b9df3d7f217',
-                'label' => 'Antal inlägg/sidor',
-                'name' => 'mod_table_pagination_count',
-                'type' => 'number',
-                'instructions' => '',
-                'required' => 0,
-                'conditional_logic' => array(
-                    array(
-                        array(
-                            'field' => 'field_60b9def7b1bf4',
-                            'operator' => '==',
-                            'value' => '1',
-                        ),
+            'use_header' => 0,
+            'use_caption' => 2,
+        ),
+        4 => array(
+            'key' => 'field_60b9def7b1bf4',
+            'label' => __('Sidbläddring', 'modularity'),
+            'name' => 'mod_table_pagination',
+            'type' => 'true_false',
+            'instructions' => '',
+            'required' => 0,
+            'conditional_logic' => 0,
+            'wrapper' => array(
+                'width' => '50',
+                'class' => '',
+                'id' => '',
+            ),
+            'message' => __('Yes, use pagination on this table', 'modularity'),
+            'default_value' => 1,
+            'ui' => 0,
+            'ui_on_text' => '',
+            'ui_off_text' => '',
+        ),
+        5 => array(
+            'key' => 'field_60b9df3d7f217',
+            'label' => __('Antal inlägg/sidor', 'modularity'),
+            'name' => 'mod_table_pagination_count',
+            'type' => 'number',
+            'instructions' => '',
+            'required' => 0,
+            'conditional_logic' => array(
+                0 => array(
+                    0 => array(
+                        'field' => 'field_60b9def7b1bf4',
+                        'operator' => '==',
+                        'value' => '1',
                     ),
                 ),
-                'wrapper' => array(
-                    'width' => '50',
-                    'class' => '',
-                    'id' => '',
-                ),
-                'default_value' => 10,
-                'placeholder' => '',
-                'prepend' => '',
-                'append' => '',
-                'min' => 1,
-                'max' => 500,
-                'step' => '',
             ),
-            array(
-                'key' => 'field_60b9df727f218',
-                'label' => 'Aktivera sök',
-                'name' => 'mod_table_search',
-                'type' => 'true_false',
-                'instructions' => '',
-                'required' => 0,
-                'conditional_logic' => 0,
-                'wrapper' => array(
-                    'width' => '50',
-                    'class' => '',
-                    'id' => '',
-                ),
-                'message' => '',
-                'default_value' => 1,
-                'ui' => 0,
-                'ui_on_text' => '',
-                'ui_off_text' => '',
+            'wrapper' => array(
+                'width' => '50',
+                'class' => '',
+                'id' => '',
             ),
-            array(
-                'key' => 'field_60b9df987f219',
-                'label' => 'Sökfras',
-                'name' => 'mod_table_search_query',
-                'type' => 'text',
-                'instructions' => '',
-                'required' => 0,
-                'conditional_logic' => array(
-                    array(
-                        array(
-                            'field' => 'field_60b9df727f218',
-                            'operator' => '==',
-                            'value' => '1',
-                        ),
+            'default_value' => 10,
+            'placeholder' => '',
+            'prepend' => '',
+            'append' => '',
+            'min' => 1,
+            'max' => 500,
+            'step' => '',
+        ),
+        6 => array(
+            'key' => 'field_60b9df727f218',
+            'label' => __('Aktivera sök', 'modularity'),
+            'name' => 'mod_table_search',
+            'type' => 'true_false',
+            'instructions' => '',
+            'required' => 0,
+            'conditional_logic' => 0,
+            'wrapper' => array(
+                'width' => '50',
+                'class' => '',
+                'id' => '',
+            ),
+            'message' => '',
+            'default_value' => 1,
+            'ui' => 0,
+            'ui_on_text' => '',
+            'ui_off_text' => '',
+        ),
+        7 => array(
+            'key' => 'field_60b9df987f219',
+            'label' => __('Sökfras', 'modularity'),
+            'name' => 'mod_table_search_query',
+            'type' => 'text',
+            'instructions' => '',
+            'required' => 0,
+            'conditional_logic' => array(
+                0 => array(
+                    0 => array(
+                        'field' => 'field_60b9df727f218',
+                        'operator' => '==',
+                        'value' => '1',
                     ),
                 ),
-                'wrapper' => array(
-                    'width' => '50',
-                    'class' => '',
-                    'id' => '',
-                ),
-                'default_value' => 'Search in list',
-                'placeholder' => '',
-                'prepend' => '',
-                'append' => '',
-                'maxlength' => '',
             ),
-            array(
-                'key' => 'field_60b9dfdf490d9',
-                'label' => 'Aktivera kolumnsortering',
-                'name' => 'mod_table_ordering',
-                'type' => 'true_false',
-                'instructions' => '',
-                'required' => 0,
-                'conditional_logic' => 0,
-                'wrapper' => array(
-                    'width' => '',
-                    'class' => '',
-                    'id' => '',
-                ),
-                'message' => 'Yes, enable column sorting',
-                'default_value' => 1,
-                'ui' => 0,
-                'ui_on_text' => '',
-                'ui_off_text' => '',
+            'wrapper' => array(
+                'width' => '50',
+                'class' => '',
+                'id' => '',
+            ),
+            'default_value' => __('Search in list', 'modularity'),
+            'placeholder' => '',
+            'prepend' => '',
+            'append' => '',
+            'maxlength' => '',
+        ),
+        8 => array(
+            'key' => 'field_60b9dfdf490d9',
+            'label' => __('Aktivera kolumnsortering', 'modularity'),
+            'name' => 'mod_table_ordering',
+            'type' => 'true_false',
+            'instructions' => '',
+            'required' => 0,
+            'conditional_logic' => 0,
+            'wrapper' => array(
+                'width' => '',
+                'class' => '',
+                'id' => '',
+            ),
+            'message' => __('Yes, enable column sorting', 'modularity'),
+            'default_value' => 1,
+            'ui' => 0,
+            'ui_on_text' => '',
+            'ui_off_text' => '',
+        ),
+    ),
+    'location' => array(
+        0 => array(
+            0 => array(
+                'param' => 'block',
+                'operator' => '==',
+                'value' => 'acf/table',
             ),
         ),
-        'location' => array(
-            array(
-                array(
-                    'param' => 'block',
-                    'operator' => '==',
-                    'value' => 'acf/table',
-                ),
-            ),
-        ),
-        'menu_order' => 0,
-        'position' => 'normal',
-        'style' => 'default',
-        'label_placement' => 'top',
-        'instruction_placement' => 'label',
-        'hide_on_screen' => '',
-        'active' => true,
-        'description' => '',
-    ));
-    
-    endif;
+    ),
+    'menu_order' => 0,
+    'position' => 'normal',
+    'style' => 'default',
+    'label_placement' => 'top',
+    'instruction_placement' => 'label',
+    'hide_on_screen' => '',
+    'active' => true,
+    'description' => '',
+));
+}

--- a/source/php/AcfFields/php/mod-table-block.php
+++ b/source/php/AcfFields/php/mod-table-block.php
@@ -12,7 +12,7 @@ if( function_exists('acf_add_local_field_group') ):
                 'name' => 'mod_table_data_type',
                 'type' => 'radio',
                 'instructions' => '',
-                'required' => 1,
+                'required' => 0,
                 'conditional_logic' => 0,
                 'wrapper' => array(
                     'width' => '',
@@ -25,7 +25,7 @@ if( function_exists('acf_add_local_field_group') ):
                 ),
                 'allow_null' => 0,
                 'other_choice' => 0,
-                'default_value' => '',
+                'default_value' => 'manual',
                 'layout' => 'horizontal',
                 'return_format' => 'value',
                 'save_other_choice' => 0,
@@ -90,7 +90,7 @@ if( function_exists('acf_add_local_field_group') ):
                 'name' => 'mod_table',
                 'type' => 'table',
                 'instructions' => '',
-                'required' => 0,
+                'required' => 1,
                 'conditional_logic' => array(
                     array(
                         array(


### PR DESCRIPTION
Add a new method that validates required fields.
Does not work on nested fields and is not intended to do that.
This is but a temporary solution until the ACF-team release
a solution.