### PR TITLE
CU-1f95zd0 fix: make block title field earliest in order

### DIFF
--- a/source/php/BlockManager.php
+++ b/source/php/BlockManager.php
@@ -361,6 +361,7 @@
         public function addBlockFieldGroup() {
             
             acf_add_local_field_group(array(
+                'menu_order' => -1,
                 'key' => 'group_block_specific',
                 'title' => __("Block settings", 'modularity'),
                 'location' => array (),


### PR DESCRIPTION
Made title field negative in menu order to always end up in top.