### PR TITLE
Added support for Script module placeholder image

### DIFF
--- a/source/php/AcfFields/json/mod-script.json
+++ b/source/php/AcfFields/json/mod-script.json
@@ -30,7 +30,7 @@
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {
-                "width": "",
+                "width": "50",
                 "class": "",
                 "id": ""
             },
@@ -40,6 +40,30 @@
             "step": "",
             "prepend": "",
             "append": ""
+        },
+        {
+            "key": "field_624f3a552ed05",
+            "label": "Placeholder image",
+            "name": "embedded_placeholder_image",
+            "type": "image",
+            "instructions": "Add a placeholder image to show where scripts cannot be rendered card",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "50",
+                "class": "",
+                "id": ""
+            },
+            "return_format": "array",
+            "preview_size": "medium",
+            "library": "all",
+            "min_width": "",
+            "min_height": "",
+            "min_size": "",
+            "max_width": "",
+            "max_height": "",
+            "max_size": "",
+            "mime_types": ""
         }
     ],
     "location": [
@@ -60,4 +84,4 @@
     "active": true,
     "description": ""
 }]
-
+

--- a/source/php/AcfFields/php/mod-script.php
+++ b/source/php/AcfFields/php/mod-script.php
@@ -1,7 +1,8 @@
-<?php 
+<?php
 
-if (function_exists('acf_add_local_field_group')) {
-    acf_add_local_field_group(array(
+
+if (function_exists('acf_add_local_field_group')) {
+    acf_add_local_field_group(array(
     'key' => 'group_56a8b9eddfced',
     'title' => __('Embed', 'modularity'),
     'fields' => array(
@@ -33,7 +34,7 @@
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
-                'width' => '',
+                'width' => '50',
                 'class' => '',
                 'id' => '',
             ),
@@ -44,6 +45,30 @@
             'prepend' => '',
             'append' => '',
         ),
+        2 => array(
+            'key' => 'field_624f3a552ed05',
+            'label' => 'Placeholder image',
+            'name' => 'embedded_placeholder_image',
+            'type' => 'image',
+            'instructions' => __('Add a placeholder image to show where scripts cannot be rendered card', 'modularity'),
+            'required' => 0,
+            'conditional_logic' => 0,
+            'wrapper' => array(
+                'width' => '50',
+                'class' => '',
+                'id' => '',
+            ),
+            'return_format' => 'array',
+            'preview_size' => 'medium',
+            'library' => 'all',
+            'min_width' => '',
+            'min_height' => '',
+            'min_size' => '',
+            'max_width' => '',
+            'max_height' => '',
+            'max_size' => '',
+            'mime_types' => '',
+        )
     ),
     'location' => array(
         0 => array(
@@ -63,4 +88,4 @@
     'active' => true,
     'description' => '',
 ));
-}
+}

--- a/source/php/Module/Script/Script.php
+++ b/source/php/Module/Script/Script.php
@@ -22,15 +22,16 @@ class Script extends \Modularity\Module
      * Removes the filter of html & script data before save.
      * @var int
      */
-    public function disableHTMLFiltering($postId) {
+    public function disableHTMLFiltering($postId)
+    {
         
         //Bail early if not a script module save
-        if(get_post_type($postId) !== "mod-" . $this->slug) {
-            return; 
+        if (get_post_type($postId) !== "mod-" . $this->slug) {
+            return;
         }
 
         //Disable filter temporarirly
-        add_filter('acf/allow_unfiltered_html', function($allow_unfiltered_html) {
+        add_filter('acf/allow_unfiltered_html', function ($allow_unfiltered_html) {
             return true;
         });
     }
@@ -39,6 +40,16 @@ class Script extends \Modularity\Module
     {
         $data = array();
         $data['embed'] = get_post_meta($this->ID, 'embed_code', true);
+
+        $placeholder = get_field('embedded_placeholder_image', $this->ID);
+        $attachment = wp_get_attachment_image_src($placeholder['ID'], [1000, false]);
+
+        $data['placeholder'] = [
+            'url' => $attachment[0],
+            'width' => $attachment[1],
+            'height' => $attachment[2],
+            'alt' => $placeholder['alt']
+        ];
 
         $data['cardPadding'] = (get_post_meta($this->ID, 'embeded_card_padding', true)) ?
             "u-padding__y--".get_post_meta($this->ID, 'embeded_card_padding', true)." u-padding__x--".

--- a/source/php/Module/Script/views/script.blade.php
+++ b/source/php/Module/Script/views/script.blade.php
@@ -13,5 +13,12 @@
         </div>
     @endif
     <div class="{{$cardPadding}}">{!! $embed !!}</div>
+    
+    @image([
+            'src'=> $placeholder['url'],
+            'alt' => $placeholder['alt'],
+            'classList' => ['box-image','u-print-display--inline-block','u-display--none']
+        ])
+    @endimage
 @endcard
 


### PR DESCRIPTION
Added support for a placeholder image in contexts where script elements cannot be rendered.

Actual placeholder is fetched from ACF and passes through Municipio hook on wp_get_attachment_src for automatic scaling (referenced by @sebastianthulin).

Implements in templates with @print media query through styleguide utility classes.