### PR TITLE
Scripts didn't work in Guteberg + other fixes

### DIFF
--- a/source/php/Module/Script/Script.php
+++ b/source/php/Module/Script/Script.php
@@ -39,7 +39,9 @@ class Script extends \Modularity\Module
     public function data() : array
     {
         $data = array();
-        $data['embed'] = get_post_meta($this->ID, 'embed_code', true);
+        $embed = get_field('embed_code', $this->ID);
+        $data['embed'] = (is_admin()) ? '<pre>'.htmlspecialchars($embed).'</pre>' : $embed;
+        
         $data['script_wrap_with'] = get_field('script_wrap_with', $this->ID) ?? 'card';
 
         $placeholder = get_field('embedded_placeholder_image', $this->ID);
@@ -52,9 +54,10 @@ class Script extends \Modularity\Module
             'alt' => $placeholder['alt']
         ];
 
-        $data['scriptPadding'] = (get_post_meta($this->ID, 'embeded_card_padding', true)) ?
-            "u-padding__y--".get_post_meta($this->ID, 'embeded_card_padding', true)." u-padding__x--".
-                get_post_meta($this->ID, 'embeded_card_padding', true) : "";
+        $data['scriptPadding'] = (get_field('embeded_card_padding', $this->ID)) ?
+            "u-padding__y--".get_field('embeded_card_padding', $this->ID)." u-padding__x--".
+                get_field('embeded_card_padding', $this->ID) : "";
+
         return $data;
     }
 

--- a/source/php/Module/Script/Script.php
+++ b/source/php/Module/Script/Script.php
@@ -63,7 +63,7 @@ class Script extends \Modularity\Module
 
     public function template()
     {
-        return $this->data['script_wrap_with'] . '.blade.php';
+        return $this->data['scriptWrapWithClassName'] . '.blade.php';
     }
 
     /**

--- a/source/php/Module/Script/Script.php
+++ b/source/php/Module/Script/Script.php
@@ -42,7 +42,7 @@ class Script extends \Modularity\Module
         $embed = get_field('embed_code', $this->ID);
         $data['embed'] = (is_admin()) ? '<pre>'.htmlspecialchars($embed).'</pre>' : $embed;
         
-        $data['script_wrap_with'] = get_field('script_wrap_with', $this->ID) ?? 'card';
+        $data['scriptWrapWithClassName'] = get_field('script_wrap_with', $this->ID) ?? 'card';
 
         $placeholder = get_field('embedded_placeholder_image', $this->ID);
         $attachment = wp_get_attachment_image_src($placeholder['ID'], [1000, false]);

--- a/source/php/Module/Script/views/nothing.blade.php
+++ b/source/php/Module/Script/views/nothing.blade.php
@@ -1,9 +1,12 @@
 <div class="{{ $classes }} script-{{$script_wrap_with}}">
     @if (!$hideTitle && !empty($postTitle))
         <div class="script-{{$script_wrap_with}}__header">
+            @php
+                $wrappingClass = 'script-'.$script_wrap_with.'-title';
+            @endphp
             @typography([
                 'element'   => 'h4',
-                'classList' => ['script-{{$script_wrap_with}}-title']
+                'classList' => [$wrappingClass]
             ])
                 {!! $postTitle !!}
             @endtypography

--- a/source/php/Module/Script/views/nothing.blade.php
+++ b/source/php/Module/Script/views/nothing.blade.php
@@ -1,8 +1,8 @@
-<div class="{{ $classes }} script-{{$script_wrap_with}}">
+<div class="{{ $classes }} script-{{$scriptWrapWithClassName}}">
     @if (!$hideTitle && !empty($postTitle))
-        <div class="script-{{$script_wrap_with}}__header">
+        <div class="script-{{$scriptWrapWithClassName}}__header">
             @php
-                $wrappingClass = 'script-'.$script_wrap_with.'-title';
+                $wrappingClass = 'script-'.$scriptWrapWithClassName.'-title';
             @endphp
             @typography([
                 'element'   => 'h4',


### PR DESCRIPTION
Fixed.
Also when it started working the scripts ran in admin, so fixed that part too.
Also som blade stuff fixed.
It's kinda strange in my opinion that there are display options on how the scripts should be wrapped and so on (leading to that they were executed in preview). It's probably not optimal now, with the script code displayed in e.g. the card component (if chosen). But it looks OK and functions. This could perhaps be the object for future discussions.