### PR TITLE
Fixed Display Taxonomies in Gutenberg

### DIFF
--- a/source/php/AcfFields/json/mod-posts-taxonomydisplay.json
+++ b/source/php/AcfFields/json/mod-posts-taxonomydisplay.json
@@ -1,0 +1,64 @@
+[{
+        "key": "group_630645d822841",
+        "title": "Visning av taxonomier",
+        "fields": [
+            {
+                "key": "field_630645dcff161",
+                "label": "Visning av taxonomier",
+                "name": "taxonomy_display",
+                "type": "acfe_taxonomies",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "taxonomy": "",
+                "field_type": "checkbox",
+                "default_value": [],
+                "return_format": "name",
+                "layout": "horizontal",
+                "toggle": 0,
+                "allow_custom": 0,
+                "multiple": 0,
+                "allow_null": 0,
+                "choices": [],
+                "ui": 0,
+                "ajax": 0,
+                "placeholder": "",
+                "search_placeholder": ""
+            }
+        ],
+        "location": [
+            [
+                {
+                    "param": "post_type",
+                    "operator": "==",
+                    "value": "mod-posts"
+                }
+            ],
+            [
+                {
+                    "param": "block",
+                    "operator": "==",
+                    "value": "acf\/posts"
+                }
+            ]
+        ],
+        "menu_order": 20,
+        "position": "normal",
+        "style": "default",
+        "label_placement": "left",
+        "instruction_placement": "label",
+        "hide_on_screen": "",
+        "active": true,
+        "description": "",
+        "show_in_rest": 0,
+        "acfe_display_title": "",
+        "acfe_autosync": "",
+        "acfe_form": 0,
+        "acfe_meta": "",
+        "acfe_note": ""
+}]

--- a/source/php/AcfFields/php/mod-posts-taxonomydisplay.php
+++ b/source/php/AcfFields/php/mod-posts-taxonomydisplay.php
@@ -1,0 +1,74 @@
+<?php
+
+
+if (function_exists('acf_add_local_field_group')) {
+
+acf_add_local_field_group(array(
+	'key' => 'group_630645d822841',
+	'title' => __('Visning av taxonomier', 'modularity'),
+	'fields' => array(
+		array(
+			'key' => 'field_630645dcff161',
+			'label' => 'Visning av taxonomier',
+            'label' => __('Visning av taxonomier', 'modularity'),
+			'name' => 'taxonomy_display',
+			'type' => 'acfe_taxonomies',
+			'instructions' => '',
+			'required' => 0,
+			'conditional_logic' => 0,
+			'wrapper' => array(
+				'width' => '',
+				'class' => '',
+				'id' => '',
+			),
+			'taxonomy' => '',
+			'field_type' => 'checkbox',
+			'default_value' => array(
+			),
+			'return_format' => 'name',
+			'layout' => 'horizontal',
+			'toggle' => 0,
+			'allow_custom' => 0,
+			'multiple' => 0,
+			'allow_null' => 0,
+			'choices' => array(
+			),
+			'ui' => 0,
+			'ajax' => 0,
+			'placeholder' => '',
+			'search_placeholder' => '',
+		),
+	),
+	'location' => array(
+		array(
+			array(
+				'param' => 'post_type',
+				'operator' => '==',
+				'value' => 'mod-posts',
+			),
+		),
+		array(
+			array(
+				'param' => 'block',
+				'operator' => '==',
+				'value' => 'acf/posts',
+			),
+		),
+	),
+	'menu_order' => 20,
+	'position' => 'normal',
+	'style' => 'default',
+	'label_placement' => 'left',
+	'instruction_placement' => 'label',
+	'hide_on_screen' => '',
+	'active' => true,
+	'description' => '',
+	'show_in_rest' => 0,
+	'acfe_display_title' => '',
+	'acfe_autosync' => '',
+	'acfe_form' => 0,
+	'acfe_meta' => '',
+	'acfe_note' => '',
+));
+
+}

--- a/source/php/Module/Posts/Posts.php
+++ b/source/php/Module/Posts/Posts.php
@@ -25,8 +25,6 @@ class Posts extends \Modularity\Module
         add_action('add_meta_boxes', array($this, 'addColumnFields'));
         add_action('save_post', array($this, 'saveColumnFields'));
 
-        add_action('admin_init', array($this, 'addTaxonomyDisplayOptions'));
-
         add_filter('acf/load_field/name=posts_date_source', array($this, 'loadDateField'));
         add_filter('acf/load_field/key=field_62a309f9c59bb', array($this, 'addIconsList'));
 
@@ -268,83 +266,6 @@ class Posts extends \Modularity\Module
         return get_field('taxonomy_display', $this->ID);
     }
 
-    /**
-     * Add options fields to setup taxonomy display
-     * i.e where to display taxonomy labels in the layout
-     */
-    public function addTaxonomyDisplayOptions()
-    {
-        if (!function_exists('acf_add_local_field_group')) {
-            return;
-        }
-
-        $taxonomies = get_taxonomies();
-        $taxonomies = array_diff($taxonomies, [
-            'nav_menu',
-            'link_category'
-        ]);
-
-        $taxonomyDisplayChoices = [];
-
-        $taxonomiesNew = [];
-        foreach ($taxonomies as $taxonomy) {
-            $tax = get_taxonomy($taxonomy);
-            $taxonomiesNew[] = $tax;
-            $taxonomyDisplayChoices[$tax->name] = $tax->label;
-        }
-
-        $taxonomies = $taxonomiesNew;
-
-        $fieldgroup = [
-            'key' => 'group_' . md5('mod_posts_taxonomy_display'),
-            'title' => __('Taxonomy display', 'municipio'),
-            'fields' => [],
-            'location' => [
-                [
-                    [
-                        'param' => 'post_type',
-                        'operator' => '==',
-                        'value' => 'mod-posts',
-                    ],
-                ],
-            ],
-            'menu_order' => 20,
-            'position' => 'normal',
-            'style' => 'default',
-            'label_placement' => 'top',
-            'instruction_placement' => 'label',
-            'hide_on_screen' => '',
-            'active' => 1,
-            'description' => '',
-        ];
-
-        $fieldgroup['fields'][] = [
-            'key' => 'field_56f00fe21f918_' . md5('display_taxonomies'),
-            'label' => 'Taxonomies to display',
-            'name' => 'taxonomy_display',
-            'type' => 'checkbox',
-            'layout' => 'horizontal',
-            'instructions' => '',
-            'required' => 0,
-            'conditional_logic' => 0,
-            'wrapper' => [
-                'width' => '',
-                'class' => '',
-                'id' => '',
-            ],
-            'choices' => $taxonomyDisplayChoices,
-            'default_value' => [],
-            'allow_null' => 0,
-            'multiple' => 0,
-            'ui' => 0,
-            'ajax' => 0,
-            'placeholder' => '',
-            'readonly' => 0,
-        ];
-
-
-        acf_add_local_field_group($fieldgroup);
-    }
 
     /**
      * AJAX CALLBACK
@@ -627,7 +548,7 @@ class Posts extends \Modularity\Module
                 return;
             }
 
-            echo '<script>var modularity_current_post_id = ' . $id . ';</script>';
+            echo '<script>modularity_current_post_id = ' . $id . ';</script>';
         });
     }
 


### PR DESCRIPTION
Display taxonomies wasn't saved when using Gutenberg.
Added json/php files for the ACF:s in question