### PR TITLE
3.0/fix/php errors

### DIFF
--- a/source/php/Display.php
+++ b/source/php/Display.php
@@ -170,7 +170,7 @@ class Display
         global $post;
         global $wp_query;
 
-        if (!$wp_query->is_main_query()) {
+        if (!$wp_query->is_main_query() || empty($post)) {
             return;
         }
 

--- a/source/php/Module/Script/Script.php
+++ b/source/php/Module/Script/Script.php
@@ -40,7 +40,11 @@ class Script extends \Modularity\Module
     {
         $data = array();
         $embed = get_field('embed_code', $this->ID);
-        $data['embed'] = (is_admin()) ? '<pre>'.htmlspecialchars($embed).'</pre>' : str_contains($embed,"<script") && !str_contains($embed,"defer" ) ? str_replace("<script", "<script defer", $embed) : $embed;
+        $data['embed'] = (is_admin()
+            ? '<pre>' . htmlspecialchars($embed) . '</pre>'
+            : (str_contains($embed, "<script") && !str_contains($embed, "defer")
+                ? str_replace("<script", "<script defer", $embed)
+                : $embed));
                 
         $data['scriptWrapWithClassName'] = get_field('script_wrap_with', $this->ID) ?? 'card';
 

--- a/source/php/Options/General.php
+++ b/source/php/Options/General.php
@@ -49,17 +49,17 @@ class General extends \Modularity\Options
 	    1000
         );
 
-	if(get_field('acf_module_restrictions', 'option')) {
 	    add_filter(
-		'Modularity/Editor/SidebarIncompability',
-		array($this, 'sidebarIncompatibility'),
-		20,
-		2
+			'Modularity/Editor/SidebarIncompability',
+			array($this, 'sidebarIncompatibility'),
+			20,
+			2
 	    );
 	    add_action('edit_form_top', function () {
-		\Modularity\ModuleManager::$enabled = $this->moduleRestriction();
+			if(get_field('acf_module_restrictions', 'option')) {
+				\Modularity\ModuleManager::$enabled = $this->moduleRestriction();
+			}
 	    });
-	}
     }
 
     /**
@@ -69,23 +69,24 @@ class General extends \Modularity\Options
      * @return array Module Specification
      */
     public function sidebarIncompatibility($moduleSpecification, $modulePostType) {
-        $template = \Modularity\Helper\Post::getPostTemplate(null, true);
-        $template_sidebars = get_field($template . '_active_sidebars', 'option');
+		if (get_field('acf_module_restrictions', 'option')) {
+			$template = \Modularity\Helper\Post::getPostTemplate(null, true);
+			$template_sidebars = get_field($template . '_active_sidebars', 'option');
 
-	if($template_sidebars) {
-	    $sidebarIncompatibilities = array_flip($template_sidebars);
-
-	    foreach($template_sidebars as $sidebar) {
-		$modules = get_field($template . '-' . $sidebar, 'option');
-		foreach($modules as $module) {
-		    if($modulePostType == $module['label']) {
-			unset($sidebarIncompatibilities[$sidebar]);
-		    }
+			if($template_sidebars) {
+				$sidebarIncompatibilities = array_flip($template_sidebars);
+				foreach($template_sidebars as $sidebar) {
+					$modules = get_field($template . '-' . $sidebar, 'option');
+					foreach($modules as $module) {
+						if($modulePostType == $module['label']) {
+						unset($sidebarIncompatibilities[$sidebar]);
+						}
+					}
+				}
+				$moduleSpecification['sidebar_incompability'] = array_keys($sidebarIncompatibilities);
+			}
 		}
-	    }
-	    $moduleSpecification['sidebar_incompability'] = array_keys($sidebarIncompatibilities);
-	}
-	return $moduleSpecification;
+		return $moduleSpecification;
     }
 
     /**


### PR DESCRIPTION
Fixes undefined values and other stuff that trigger PHP errors. 

Fixes: 
- global $post can be null on 404 pages (Display.php)
- wrap nested ternary with parentheses (Module\Script\Script.php)
- move get_field checks within the hooks (Options\General.php)