### PR TITLE
statically cache "Editor\getPostModules" results.

### DIFF
--- a/source/php/Editor.php
+++ b/source/php/Editor.php
@@ -384,7 +384,14 @@ class Editor extends \Modularity\Options
     public static function getPostModules($postId)
     {
 
-        //Declarations
+        // Cached results
+        static $cachedResults;
+
+        if(isset($cachedResults)) {
+            return $cachedResults;
+        }
+
+        //Declarations        
         $modules = array();
         $retModules = array();
 
@@ -392,7 +399,6 @@ class Editor extends \Modularity\Options
         $postId = self::pageForPostTypeTranscribe($postId);
 
         // Get enabled modules
-        $available = \Modularity\ModuleManager::$available;
         $enabled = \Modularity\ModuleManager::$enabled;
 
         // Get modules structure
@@ -473,6 +479,9 @@ class Editor extends \Modularity\Options
                 }
             }
         }
+
+        // Cache results to reuse in the same instance
+        $cachedResults = $retModules;
 
         return $retModules;
     }


### PR DESCRIPTION
Every time this function is called it grabs data for all modules and posts, and it's requested for all modules.

As we already get all the data we want the first time, and the $postId doesn't change in the same instance as far as i know. We can gain a significant speedboost during loading by doing caching it. (The more modules used on the post the higher the gain).

remove the unused $available variable.