### PR TITLE
improve performance when grabbing module posts.

### DIFF
--- a/source/php/Editor.php
+++ b/source/php/Editor.php
@@ -384,7 +384,14 @@ class Editor extends \Modularity\Options
     public static function getPostModules($postId)
     {
 
-        //Declarations
+        // Cached results
+        static $cachedResults;
+
+        if(isset($cachedResults)) {
+            return $cachedResults;
+        }
+
+        //Declarations        
         $modules = array();
         $retModules = array();
 
@@ -392,7 +399,6 @@ class Editor extends \Modularity\Options
         $postId = self::pageForPostTypeTranscribe($postId);
 
         // Get enabled modules
-        $available = \Modularity\ModuleManager::$available;
         $enabled = \Modularity\ModuleManager::$enabled;
 
         // Get modules structure
@@ -473,6 +479,9 @@ class Editor extends \Modularity\Options
                 }
             }
         }
+
+        // Cache results to reuse in the same instance
+        $cachedResults = $retModules;
 
         return $retModules;
     }

--- a/source/php/Editor.php
+++ b/source/php/Editor.php
@@ -431,17 +431,17 @@ class Editor extends \Modularity\Options
         }
 
         // Get module posts
-        $modulesPosts = get_posts(array(
-            'posts_per_page' => -1,
-            'post_type' => $enabled,
-            'include' => $moduleIds,
-            'post_status' => $postStatuses
-        ));
-
-        // Add module id's as keys in the array
-        if (!empty($modulesPosts)) {
-            foreach ($modulesPosts as $module) {
-                $modules[$module->ID] = $module;
+        if (!(empty($moduleIds) || empty($enabled) || empty($postStatuses))) {
+            global $wpdb;
+            $format_statement = fn ($a, $raw = false) => implode(',', $raw ? $a : array_map(fn ($v) => "'" . esc_sql($v) . "'", $a));
+            $prepared = $wpdb->prepare("SELECT ID FROM `$wpdb->posts` WHERE `ID` IN (" . $format_statement($moduleIds, true) . ") AND `post_type` IN (" .  $format_statement($enabled) . ") AND `post_status` IN (" . $format_statement($postStatuses) . ")");
+            $modulesPosts = $wpdb->get_results($prepared);
+            
+            // Add module id's as keys in the array
+            if (!empty($modulesPosts)) {
+                foreach ($modulesPosts as $module) {
+                    $modules[$module->ID] = $module;
+                }
             }
         }
 


### PR DESCRIPTION
using `$wpdb` and only getting the ID has quite a bit less overhead compared to `get_posts`.

As the results are cached this only affects the first run each instance.

I'm unsure what the preferred formatting is for the project,
and i probably broken some here (at least on the `$format_statement`):p