### PR TITLE
Block core/list broken

### DIFF
--- a/source/php/BlockManager.php
+++ b/source/php/BlockManager.php
@@ -142,6 +142,7 @@ class BlockManager
                 'core/paragraph',
                 'core/more',
                 'core/list',
+                'core/list-item',
                 'core/shortcode',
                 'core/block',
                 'core/image'


### PR DESCRIPTION
Block type broken due to sub block type core/list-item not registered in allowed block types.