### PR TITLE
fix: add an unset of global $post in CachePurge.php

### DIFF
--- a/source/php/CachePurge.php
+++ b/source/php/CachePurge.php
@@ -86,6 +86,8 @@ class CachePurge
 
                     wp_cache_delete($moduleId, $this->keyGroup);
                 }
+
+                unset($GLOBALS['post']);
             }
         }
 


### PR DESCRIPTION
We encountered a bug where the wrong template is used in the Modularity edit page in the wp admin after clicking 'save'. If the correct template has different area settings than the incorrect one, it means that the modules will not show up. A page refresh will make them appear again. However if clicking 'save' one more time before refreshing then the modules will actually be deleted from the database.

From what I found the issue seems to be in `CachePurge.php` at this while loop:

```
while ($query->have_posts()) {
          $query->the_post();
          $moduleId = get_the_ID();

          wp_cache_delete($moduleId, $this->keyGroup);
}
```

Since `$query->the_post();` will set the global `$post` it will end up being set to the last item after the loop has finished.

Then in `Post.php` we have this logic:

```
 // If $post is empty try to fetc post from querystring
  if (!$post && isset($_GET['id']) && is_numeric($_GET['id'])) {
    $post = get_post($_GET['id']);

    if (!$post) {
      throw new \Error('The requested post was not found.');
    }
  }
```

So if the global $post is set at this point it will skip getting it from the query id and continue to use the last item from the cache purge loop.

This causes for example the template to be determined by the post type of this incorrect post. So when clicking `save` the template can change from for example `one-page` to `single`, which explains why the wrong areas are shown and thus the modules seem to disappear since there is no div with correct id to inject them to.

I'm not sure what is the best way of fixing it, but I tried adding this line after the while loop:

```
unset($GLOBALS['post']);
```

To make sure that the global `$post` is unset and therefore the post will be determined from the url query id instead.
   