### PR TITLE
fix: tell query number of expected modules

### DIFF
--- a/source/php/Editor.php
+++ b/source/php/Editor.php
@@ -454,7 +454,7 @@ class Editor extends \Modularity\Options
 
         // Get module posts
         $modulesPosts = get_posts(array(
-            'posts_per_page' => -1,
+            'posts_per_page' => count($moduleIds) * 2 ?? -1,
             'post_type' => $enabled,
             'include' => $moduleIds,
             'post_status' => $postStatuses


### PR DESCRIPTION
This value is doubled, to enshure that any potential problems dosen't occur. We may add tests, in order to set a more definite amount of items.