### PR TITLE
fix: removes unrecongnized sidebar context in hero module.

### DIFF
--- a/source/php/Module/Hero/views/image.blade.php
+++ b/source/php/Module/Hero/views/image.blade.php
@@ -9,7 +9,6 @@
     "paragraph" => $paragraph,
     "stretch" => isset($blockData) ? ((bool) $blockData['align'] == 'full') : $stretch,
     "context" => ['hero', 'module.hero', 'module.hero.image', $sidebarContext . '.animation-item'],
-    "sidebar" => $sidebarContext ? $sidebarContext : false,
     "ariaLabel" => $ariaLabel,
     "heroView" => $heroView,
     "buttonArgs" => $buttonArgs


### PR DESCRIPTION
Gets passed in context param instead.