### PR TITLE
fix(mod-posts): incorrect permalink to other sites posts

### DIFF
--- a/source/php/Module/Posts/Helper/GetPosts.php
+++ b/source/php/Module/Posts/Helper/GetPosts.php
@@ -55,7 +55,13 @@ class GetPosts
             foreach($fields['posts_data_network_sources'] as $site) {
                 switch_to_blog($site);
                 $wpQuery = new \WP_Query($this->getPostArgs($fields, $page));
-                $posts = array_merge($posts, $wpQuery->get_posts());
+                $postsFromOtherSite = $wpQuery->get_posts();
+
+                array_walk($postsFromOtherSite, function($post) {
+                    $post->originalPermalink = get_permalink($post->ID);
+                });
+
+                $posts = array_merge($posts, $postsFromOtherSite);
                 $maxNumPages = max($maxNumPages, $wpQuery->max_num_pages);
                 restore_current_blog();
             }

--- a/source/php/Module/Posts/Helper/GetPosts.php
+++ b/source/php/Module/Posts/Helper/GetPosts.php
@@ -55,13 +55,14 @@ class GetPosts
             foreach($fields['posts_data_network_sources'] as $site) {
                 switch_to_blog($site);
                 $wpQuery = new \WP_Query($this->getPostArgs($fields, $page));
-                $postsFromOtherSite = $wpQuery->get_posts();
+                $postsFromSite = $wpQuery->get_posts();
 
-                array_walk($postsFromOtherSite, function($post) {
+                array_walk($postsFromSite, function($post) {
+                    // Add the original permalink to the post object for reference in network sources.
                     $post->originalPermalink = get_permalink($post->ID);
                 });
 
-                $posts = array_merge($posts, $postsFromOtherSite);
+                $posts = array_merge($posts, $postsFromSite);
                 $maxNumPages = max($maxNumPages, $wpQuery->max_num_pages);
                 restore_current_blog();
             }

--- a/source/php/Module/Posts/TemplateController/ListTemplate.php
+++ b/source/php/Module/Posts/TemplateController/ListTemplate.php
@@ -43,7 +43,7 @@ class ListTemplate
                 if (!empty($post->postType) && $post->postType == 'attachment') {
                     $link = wp_get_attachment_url($post->id);
                 } else {
-                    $link = $post->permalink;
+                    $link = $post->originalPermalink ?? $post->permalink;
                 }
     
                 if (!empty($post->postTitle)) {


### PR DESCRIPTION
This pull request includes changes to improve the handling of post permalinks when fetching posts from multiple sites. The most important changes are in the `GetPosts.php` and `ListTemplate.php` files.

Improvements to permalink handling:

* [`source/php/Module/Posts/Helper/GetPosts.php`](diffhunk://#diff-38bb160590c235cf5e69c693a8492cebeb9148eb34398558504db10765d36e5aL58-R64): Added `originalPermalink` to each post fetched from other sites to ensure the permalink is correctly stored.
* [`source/php/Module/Posts/TemplateController/ListTemplate.php`](diffhunk://#diff-3e77677d2039d4609b13d8eda845eabb1cf4aaaa579d1bd664635ec516fdf86bL46-R46): Modified the permalink assignment to use `originalPermalink` if available, ensuring the correct permalink is used for posts.