### PR TITLE
fix(posts): remove limit on site query (default was 100)

### DIFF
--- a/source/php/Module/Posts/Posts.php
+++ b/source/php/Module/Posts/Posts.php
@@ -93,7 +93,7 @@ class Posts extends \Modularity\Module
 
         $field['choices'] = [];
 
-        foreach (get_sites() as $site) {
+        foreach (get_sites(['number' => 0]) as $site) {
             switch_to_blog($site->blog_id);
             $field['choices'][$site->blog_id] = get_bloginfo('name');
             restore_current_blog();


### PR DESCRIPTION
This pull request includes a modification to the `loadNetworkSourcesField` function in the `Posts.php` file to improve the efficiency of retrieving site information.

Improvements to efficiency:

* [`source/php/Module/Posts/Posts.php`](diffhunk://#diff-a319adf96c3b45b0665ad99c309d7b0b73484b508a634c21889d97a3f724c26bL96-R96): Updated the `get_sites` function call to include the `['number' => 0]` parameter, ensuring all sites are retrieved without a limit. This change optimizes the process of fetching site data.