### PR TITLE
refactor(mod-posts): avoid missing one post when used as archive module

### DIFF
--- a/source/php/Module/Posts/Helper/GetPosts.php
+++ b/source/php/Module/Posts/Helper/GetPosts.php
@@ -5,6 +5,8 @@ namespace Modularity\Module\Posts\Helper;
 use Modularity\Helper\WpQueryFactory\WpQueryFactoryInterface;
 use WpService\Contracts\GetPermalink;
 use WpService\Contracts\GetPostType;
+use WpService\Contracts\GetTheID;
+use WpService\Contracts\IsArchive;
 use WpService\Contracts\IsUserLoggedIn;
 use WpService\Contracts\RestoreCurrentBlog;
 use WpService\Contracts\SwitchToBlog;
@@ -12,7 +14,7 @@ use WpService\Contracts\SwitchToBlog;
 class GetPosts
 {
     public function __construct(
-        private IsUserLoggedIn&SwitchToBlog&RestoreCurrentBlog&GetPermalink&GetPostType $wpService,
+        private IsUserLoggedIn&SwitchToBlog&RestoreCurrentBlog&GetPermalink&GetPostType&IsArchive&GetTheID $wpService,
         private WpQueryFactoryInterface $wpQueryFactory
     )
     {
@@ -243,12 +245,15 @@ class GetPosts
         return $postTypes;
     }
 
-    public function getCurrentPostID()
+    /**
+     * Get the current post ID
+     */
+    public function getCurrentPostID():int|false
     {
-        global $post;
-        if (isset($post->ID) && is_numeric($post->ID)) {
-            return $post->ID;
+        if ($this->wpService->isArchive()) {
+            return false;
         }
-        return false;
+
+        return $this->wpService->getTheID();
     }
 }

--- a/source/php/Module/Posts/Helper/GetPosts.php
+++ b/source/php/Module/Posts/Helper/GetPosts.php
@@ -3,13 +3,15 @@
 namespace Modularity\Module\Posts\Helper;
 
 use Modularity\Helper\WpQueryFactory\WpQueryFactoryInterface;
-use WpService\Contracts\GetPermalink;
-use WpService\Contracts\GetPostType;
-use WpService\Contracts\GetTheID;
-use WpService\Contracts\IsArchive;
-use WpService\Contracts\IsUserLoggedIn;
-use WpService\Contracts\RestoreCurrentBlog;
-use WpService\Contracts\SwitchToBlog;
+use WpService\Contracts\{
+    GetPermalink,
+    GetPostType,
+    GetTheID,
+    IsArchive,
+    IsUserLoggedIn,
+    RestoreCurrentBlog,
+    SwitchToBlog,
+};
 
 class GetPosts
 {

--- a/source/php/Module/Posts/Helper/GetPostsTest.php
+++ b/source/php/Module/Posts/Helper/GetPostsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Modularity\Module\Posts\Helper;
+
+use Modularity\Helper\WpQueryFactory\WpQueryFactoryInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use WpService\Implementations\FakeWpService;
+
+class GetPostsTest extends TestCase {
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['post']);
+    }
+
+    #[TestDox('getCurrentPostID() returns the current post ID')]
+    public function testGetCurrentPostIDReturnsTheCurrentPostID() {
+        $wpService = new FakeWpService(['getTheID' => 1, 'isArchive' => false]);
+        $wpQueryFactory = $this->createStub(WpQueryFactoryInterface::class);
+        
+        $getPosts = new GetPosts($wpService, $wpQueryFactory);
+
+        $this->assertEquals(1, $getPosts->getCurrentPostID());
+    }
+    
+    #[TestDox('getCurrentPostID() returns false when post is not set')]
+    public function testGetCurrentPostIDReturnsFalseWhenPostIsNotSet() {
+        $wpService = new FakeWpService(['getTheID' => false, 'isArchive' => false]);
+        $wpQueryFactory = $this->createStub(WpQueryFactoryInterface::class);
+        
+        $getPosts = new GetPosts($wpService, $wpQueryFactory);
+
+        $this->assertFalse($getPosts->getCurrentPostID());
+    }
+    
+    
+    #[TestDox('getCurrentPostID() returns false when in archive context')]
+    public function testGetCurrentPostIDReturnsFalseWhenInArchiveContext() {
+        $wpService = new FakeWpService(['getTheID' => 1, 'isArchive' => true]);
+        $wpQueryFactory = $this->createStub(WpQueryFactoryInterface::class);
+        
+        $getPosts = new GetPosts($wpService, $wpQueryFactory);
+
+        $this->assertFalse($getPosts->getCurrentPostID());
+    }
+}

--- a/source/php/Module/Posts/Helper/GetPostsTest.php
+++ b/source/php/Module/Posts/Helper/GetPostsTest.php
@@ -9,11 +9,6 @@ use WpService\Implementations\FakeWpService;
 
 class GetPostsTest extends TestCase {
 
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['post']);
-    }
-
     #[TestDox('getCurrentPostID() returns the current post ID')]
     public function testGetCurrentPostIDReturnsTheCurrentPostID() {
         $wpService = new FakeWpService(['getTheID' => 1, 'isArchive' => false]);


### PR DESCRIPTION
This pull request introduces enhancements to the `GetPosts` class in the `source/php/Module/Posts/Helper` directory, including dependency injection improvements and the addition of unit tests. The most important changes are the inclusion of new service contracts, the refactoring of the `getCurrentPostID` method, and the creation of a new test class for `GetPosts`.

### Dependency Injection Improvements:
* [`source/php/Module/Posts/Helper/GetPosts.php`](diffhunk://#diff-38bb160590c235cf5e69c693a8492cebeb9148eb34398558504db10765d36e5aR8-R17): Added `GetTheID` and `IsArchive` contracts to the constructor for better encapsulation and service usage.

### Method Refactoring:
* [`source/php/Module/Posts/Helper/GetPosts.php`](diffhunk://#diff-38bb160590c235cf5e69c693a8492cebeb9148eb34398558504db10765d36e5aL246-R258): Refactored the `getCurrentPostID` method to utilize the new `IsArchive` and `GetTheID` services, improving code clarity and responsibility separation.

### Unit Tests:
* [`source/php/Module/Posts/Helper/GetPostsTest.php`](diffhunk://#diff-46af7dac42f34c5a246502310885ad6b6dae752b1e1e1914f8195097b513f1acR1-R47): Added a new test class `GetPostsTest` with tests for the `getCurrentPostID` method, ensuring it returns the correct post ID or `false` based on different conditions.