### PR TITLE
feat(GetPosts): add sorting functionality for posts by various criteria

### DIFF
--- a/source/php/Module/Posts/Helper/GetPosts.php
+++ b/source/php/Module/Posts/Helper/GetPosts.php
@@ -88,6 +88,7 @@ class GetPosts
             }
 
             // Limit the number of posts to the desired count to avoid exceeding the limit.
+            $posts = $this->sortPosts($posts, $fields['posts_sort_by'] ?? 'date', $fields['posts_sort_order'] ?? 'desc');
             $posts = array_slice($posts, 0, $this->getPostsPerPage($fields));
 
             return [
@@ -257,5 +258,21 @@ class GetPosts
         }
 
         return $this->wpService->getTheID();
+    }
+
+    public function sortPosts(array $posts, string $orderby = 'date', string $order = 'desc') : array
+    {
+        usort($posts, fn($a, $b) =>
+            match($orderby) {
+                'date' => strtotime($a->post_date) > strtotime($b->post_date) ? ($order == 'asc' ? 1 : -1) : ($order == 'asc' ? -1 : 1),
+                'title' => $a->post_title > $b->post_title ? ($order == 'asc' ? 1 : -1) : ($order == 'asc' ? -1 : 1),
+                'modified' => strtotime($a->post_modified) > strtotime($b->post_modified) ? ($order == 'asc' ? 1 : -1) : ($order == 'asc' ? -1 : 1),
+                'menu_order' => $a->menu_order > $b->menu_order ? ($order == 'asc' ? 1 : -1) : ($order == 'asc' ? -1 : 1),
+                'rand' => rand(-1, 1),
+                default => 0,
+            }
+        );
+
+        return $posts;
     }
 }

--- a/source/php/Module/Posts/Helper/GetPosts.php
+++ b/source/php/Module/Posts/Helper/GetPosts.php
@@ -260,6 +260,13 @@ class GetPosts
         return $this->wpService->getTheID();
     }
 
+    /**
+     * Sort posts
+     * 
+     * @param \WP_Post[] $posts
+     * @param string $orderby Can be 'date', 'title', 'modified', 'menu_order', 'rand'. Default is 'date'.
+     * @param string $order Can be 'asc' or 'desc'. Default is 'desc'. When 'rand' is used, this parameter is ignored.
+     */
     public function sortPosts(array $posts, string $orderby = 'date', string $order = 'desc') : array
     {
         usort($posts, fn($a, $b) =>

--- a/source/php/Module/Posts/Helper/GetPostsTest.php
+++ b/source/php/Module/Posts/Helper/GetPostsTest.php
@@ -226,6 +226,26 @@ class GetPostsTest extends TestCase {
         $this->assertNotEquals($secondSort, $posts); // Assert that the posts are not in the same order
     }
 
+    #[TestDox('sortPosts() does not sort if invalid sort order is provided')]
+    public function testSortPostsDoesNotSortIfInvalidSortOrderIsProvided() {
+        $posts = [
+            $this->getWpPostMock(['menu_order' => 3]),
+            $this->getWpPostMock(['menu_order' => 1]),
+            $this->getWpPostMock(['menu_order' => 2]),
+        ];
+
+        $wpService = new FakeWpService(['getTheID' => 1, 'isArchive' => false]);
+        $wpQueryFactory = $this->createStub(WpQueryFactoryInterface::class);
+        
+        $getPosts = new GetPosts($wpService, $wpQueryFactory);
+
+        $sortedPosts = $getPosts->sortPosts($posts, 'foo');
+
+        $this->assertEquals(3, $sortedPosts[0]->menu_order);
+        $this->assertEquals(1, $sortedPosts[1]->menu_order);
+        $this->assertEquals(2, $sortedPosts[2]->menu_order);
+    }
+
     private function getWpPostMock(array $data = []):WP_Post|MockObject {
         $wpPost = $this->createStub(stdClass::class);
         $wpPost->post_date = $data['post_date'] ?? '';

--- a/source/php/Module/Posts/Helper/GetPostsTest.php
+++ b/source/php/Module/Posts/Helper/GetPostsTest.php
@@ -4,7 +4,10 @@ namespace Modularity\Module\Posts\Helper;
 
 use Modularity\Helper\WpQueryFactory\WpQueryFactoryInterface;
 use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use stdClass;
+use WP_Post;
 use WpService\Implementations\FakeWpService;
 
 class GetPostsTest extends TestCase {
@@ -29,7 +32,6 @@ class GetPostsTest extends TestCase {
         $this->assertFalse($getPosts->getCurrentPostID());
     }
     
-    
     #[TestDox('getCurrentPostID() returns false when in archive context')]
     public function testGetCurrentPostIDReturnsFalseWhenInArchiveContext() {
         $wpService = new FakeWpService(['getTheID' => 1, 'isArchive' => true]);
@@ -38,5 +40,200 @@ class GetPostsTest extends TestCase {
         $getPosts = new GetPosts($wpService, $wpQueryFactory);
 
         $this->assertFalse($getPosts->getCurrentPostID());
+    }
+
+    #[TestDox('sortPosts() sorts posts by date descending')]
+    public function testSortPostsSortsPostsByDate() {
+        $posts = [
+            $this->getWpPostMock(['post_date' => '2021-01-01']),
+            $this->getWpPostMock(['post_date' => '2021-01-03']),
+            $this->getWpPostMock(['post_date' => '2021-01-02']),
+        ];
+
+        $wpService = new FakeWpService(['getTheID' => 1, 'isArchive' => false]);
+        $wpQueryFactory = $this->createStub(WpQueryFactoryInterface::class);
+        
+        $getPosts = new GetPosts($wpService, $wpQueryFactory);
+
+        $sortedPosts = $getPosts->sortPosts($posts, 'date', 'desc');
+
+        $this->assertEquals('2021-01-03', $sortedPosts[0]->post_date);
+        $this->assertEquals('2021-01-02', $sortedPosts[1]->post_date);
+        $this->assertEquals('2021-01-01', $sortedPosts[2]->post_date);
+    }
+
+    #[TestDox('sortPosts() sorts posts by date ascending')]
+    public function testSortPostsSortsPostsByDateAscending() {
+        $posts = [
+            $this->getWpPostMock(['post_date' => '2021-01-01']),
+            $this->getWpPostMock(['post_date' => '2021-01-03']),
+            $this->getWpPostMock(['post_date' => '2021-01-02']),
+        ];
+
+        $wpService = new FakeWpService(['getTheID' => 1, 'isArchive' => false]);
+        $wpQueryFactory = $this->createStub(WpQueryFactoryInterface::class);
+        
+        $getPosts = new GetPosts($wpService, $wpQueryFactory);
+
+        $sortedPosts = $getPosts->sortPosts($posts, 'date', 'asc');
+
+        $this->assertEquals('2021-01-01', $sortedPosts[0]->post_date);
+        $this->assertEquals('2021-01-02', $sortedPosts[1]->post_date);
+        $this->assertEquals('2021-01-03', $sortedPosts[2]->post_date);
+    }
+
+    #[TestDox('sortPosts() sorts posts by title descending')]
+    public function testSortPostsSortsPostsByTitleDescending() {
+        $posts = [
+            $this->getWpPostMock(['post_title' => 'C']),
+            $this->getWpPostMock(['post_title' => 'A']),
+            $this->getWpPostMock(['post_title' => 'B']),
+        ];
+
+        $wpService = new FakeWpService(['getTheID' => 1, 'isArchive' => false]);
+        $wpQueryFactory = $this->createStub(WpQueryFactoryInterface::class);
+        
+        $getPosts = new GetPosts($wpService, $wpQueryFactory);
+
+        $sortedPosts = $getPosts->sortPosts($posts, 'title', 'desc');
+
+        $this->assertEquals('C', $sortedPosts[0]->post_title);
+        $this->assertEquals('B', $sortedPosts[1]->post_title);
+        $this->assertEquals('A', $sortedPosts[2]->post_title);
+    }
+
+    #[TestDox('sortPosts() sorts posts by title ascending')]
+    public function testSortPostsSortsPostsByTitleAscending() {
+        $posts = [
+            $this->getWpPostMock(['post_title' => 'C']),
+            $this->getWpPostMock(['post_title' => 'A']),
+            $this->getWpPostMock(['post_title' => 'B']),
+        ];
+
+        $wpService = new FakeWpService(['getTheID' => 1, 'isArchive' => false]);
+        $wpQueryFactory = $this->createStub(WpQueryFactoryInterface::class);
+        
+        $getPosts = new GetPosts($wpService, $wpQueryFactory);
+
+        $sortedPosts = $getPosts->sortPosts($posts, 'title', 'asc');
+
+        $this->assertEquals('A', $sortedPosts[0]->post_title);
+        $this->assertEquals('B', $sortedPosts[1]->post_title);
+        $this->assertEquals('C', $sortedPosts[2]->post_title);
+    }
+
+    #[TestDox('sortPosts() sorts posts by modified date descending')]
+    public function testSortPostsSortsPostsByModifiedDateDescending() {
+        $posts = [
+            $this->getWpPostMock(['post_modified' => '2021-01-01']),
+            $this->getWpPostMock(['post_modified' => '2021-01-03']),
+            $this->getWpPostMock(['post_modified' => '2021-01-02']),
+        ];
+
+        $wpService = new FakeWpService(['getTheID' => 1, 'isArchive' => false]);
+        $wpQueryFactory = $this->createStub(WpQueryFactoryInterface::class);
+        
+        $getPosts = new GetPosts($wpService, $wpQueryFactory);
+
+        $sortedPosts = $getPosts->sortPosts($posts, 'modified', 'desc');
+
+        $this->assertEquals('2021-01-03', $sortedPosts[0]->post_modified);
+        $this->assertEquals('2021-01-02', $sortedPosts[1]->post_modified);
+        $this->assertEquals('2021-01-01', $sortedPosts[2]->post_modified);
+    }
+
+    #[TestDox('sortPosts() sorts posts by modified date ascending')]
+    public function testSortPostsSortsPostsByModifiedDateAscending() {
+        $posts = [
+            $this->getWpPostMock(['post_modified' => '2021-01-01']),
+            $this->getWpPostMock(['post_modified' => '2021-01-03']),
+            $this->getWpPostMock(['post_modified' => '2021-01-02']),
+        ];
+
+        $wpService = new FakeWpService(['getTheID' => 1, 'isArchive' => false]);
+        $wpQueryFactory = $this->createStub(WpQueryFactoryInterface::class);
+        
+        $getPosts = new GetPosts($wpService, $wpQueryFactory);
+
+        $sortedPosts = $getPosts->sortPosts($posts, 'modified', 'asc');
+
+        $this->assertEquals('2021-01-01', $sortedPosts[0]->post_modified);
+        $this->assertEquals('2021-01-02', $sortedPosts[1]->post_modified);
+        $this->assertEquals('2021-01-03', $sortedPosts[2]->post_modified);
+    }
+
+    #[TestDox('sortPosts() sorts posts by menu order descending')]
+    public function testGetPostsSortsPostsByMenuOrderDescending() {
+        $posts = [
+            $this->getWpPostMock(['menu_order' => 3]),
+            $this->getWpPostMock(['menu_order' => 1]),
+            $this->getWpPostMock(['menu_order' => 2]),
+        ];
+
+        $wpService = new FakeWpService(['getTheID' => 1, 'isArchive' => false]);
+        $wpQueryFactory = $this->createStub(WpQueryFactoryInterface::class);
+        
+        $getPosts = new GetPosts($wpService, $wpQueryFactory);
+
+        $sortedPosts = $getPosts->sortPosts($posts, 'menu_order', 'desc');
+
+        $this->assertEquals(3, $sortedPosts[0]->menu_order);
+        $this->assertEquals(2, $sortedPosts[1]->menu_order);
+        $this->assertEquals(1, $sortedPosts[2]->menu_order);
+    }
+
+    #[TestDox('sortPosts() sorts posts by menu order ascending')]
+    public function testGetPostsSortsPostsByMenuOrderAscending() {
+        $posts = [
+            $this->getWpPostMock(['menu_order' => 3]),
+            $this->getWpPostMock(['menu_order' => 1]),
+            $this->getWpPostMock(['menu_order' => 2]),
+        ];
+
+        $wpService = new FakeWpService(['getTheID' => 1, 'isArchive' => false]);
+        $wpQueryFactory = $this->createStub(WpQueryFactoryInterface::class);
+        
+        $getPosts = new GetPosts($wpService, $wpQueryFactory);
+
+        $sortedPosts = $getPosts->sortPosts($posts, 'menu_order', 'asc');
+
+        $this->assertEquals(1, $sortedPosts[0]->menu_order);
+        $this->assertEquals(2, $sortedPosts[1]->menu_order);
+        $this->assertEquals(3, $sortedPosts[2]->menu_order);
+    }
+
+    #[TestDox('sortPosts() sorts posts randomly')]
+    public function testSortPostsSortsPostsRandomly() {
+        
+        $numberOfPosts = 20;
+        $posts = array_map(function($i) {
+            return $this->getWpPostMock(['ID' => $i]);
+        }, range(1, $numberOfPosts));
+
+        $wpService = new FakeWpService(['getTheID' => 1, 'isArchive' => false]);
+        $wpQueryFactory = $this->createStub(WpQueryFactoryInterface::class);
+        
+        $getPosts = new GetPosts($wpService, $wpQueryFactory);
+
+        $firstSort = $getPosts->sortPosts($posts, 'rand', 'asc');
+        $secondSort = $getPosts->sortPosts($posts, 'rand', 'asc');
+
+        $this->assertEqualsCanonicalizing($posts, $firstSort); // Assert that the posts are the same
+        $this->assertEqualsCanonicalizing($posts, $secondSort); // Assert that the posts are the same
+
+        $this->assertNotEquals($firstSort, $secondSort); // Assert that the posts are not in the same order
+        $this->assertNotEquals($firstSort, $posts); // Assert that the posts are not in the same order
+        $this->assertNotEquals($secondSort, $posts); // Assert that the posts are not in the same order
+    }
+
+    private function getWpPostMock(array $data = []):WP_Post|MockObject {
+        $wpPost = $this->createStub(stdClass::class);
+        $wpPost->post_date = $data['post_date'] ?? '';
+        $wpPost->post_title = $data['post_title'] ?? '';
+        $wpPost->post_modified = $data['post_modified'] ?? '';
+        $wpPost->menu_order = $data['menu_order'] ?? 0;
+        $wpPost->ID = $data['ID'] ?? 0;
+        
+        return $wpPost;
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature to sort posts by various criteria and includes corresponding unit tests to ensure the functionality works as expected. The key changes involve adding a new method to sort posts and updating the test suite to cover the new sorting functionality.

### New Feature: Post Sorting

* Added `sortPosts` method to `GetPosts` class to sort posts by date, title, modified date, menu order, or randomly.
* Updated `getPostsFromSelectedSites` method to use the new `sortPosts` method for sorting posts before limiting the number of posts.

### Unit Tests

* Added multiple test cases in `GetPostsTest` to verify the `sortPosts` method sorts posts correctly by different criteria and orders.
* Included utility method `getWpPostMock` in `GetPostsTest` to create mock `WP_Post` objects for testing.
* Imported necessary classes and interfaces for the new tests in `GetPostsTest`.