### PR TITLE
feat: add option to use term icon in posts list and update related logic

### DIFF
--- a/source/php/AcfFields/json/mod-posts-displau.json
+++ b/source/php/AcfFields/json/mod-posts-displau.json
@@ -35,6 +35,35 @@
             "save_other_choice": 0
         },
         {
+            "key": "field_675c0e6f7becc",
+            "label": "Use term icon as icon in list",
+            "name": "use_term_icon_as_icon_in_list",
+            "aria-label": "",
+            "type": "true_false",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_571dfd4c0d9d9",
+                        "operator": "==",
+                        "value": "list"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "",
+            "default_value": 0,
+            "allow_in_bindings": 0,
+            "ui": 0,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        },
+        {
             "key": "field_636249fee87cc",
             "label": "Preamble",
             "name": "preamble",

--- a/source/php/AcfFields/php/mod-posts-displau.php
+++ b/source/php/AcfFields/php/mod-posts-displau.php
@@ -30,7 +30,7 @@
                 'segment' => __('Segment', 'modularity'),
                 'collection' => __('Collection', 'modularity'),
             ),
-            'default_value' => 'list',
+            'default_value' => __('list', 'modularity'),
             'return_format' => 'value',
             'allow_null' => 0,
             'other_choice' => 0,
@@ -38,6 +38,35 @@
             'save_other_choice' => 0,
         ),
         1 => array(
+            'key' => 'field_675c0e6f7becc',
+            'label' => __('Use term icon as icon in list', 'modularity'),
+            'name' => 'use_term_icon_as_icon_in_list',
+            'aria-label' => '',
+            'type' => 'true_false',
+            'instructions' => '',
+            'required' => 0,
+            'conditional_logic' => array(
+                0 => array(
+                    0 => array(
+                        'field' => 'field_571dfd4c0d9d9',
+                        'operator' => '==',
+                        'value' => 'list',
+                    ),
+                ),
+            ),
+            'wrapper' => array(
+                'width' => '',
+                'class' => '',
+                'id' => '',
+            ),
+            'message' => '',
+            'default_value' => 0,
+            'allow_in_bindings' => 0,
+            'ui' => 0,
+            'ui_on_text' => '',
+            'ui_off_text' => '',
+        ),
+        2 => array(
             'key' => 'field_636249fee87cc',
             'label' => __('Preamble', 'modularity'),
             'name' => 'preamble',
@@ -100,7 +129,7 @@
             'prepend' => '',
             'append' => '',
         ),
-        2 => array(
+        3 => array(
             'key' => 'field_6356477fbc5e4',
             'label' => __('Show as slider', 'modularity'),
             'name' => 'show_as_slider',
@@ -163,7 +192,7 @@
             'ui_off_text' => '',
             'ui' => 1,
         ),
-        3 => array(
+        4 => array(
             'key' => 'field_6418289cf23a6',
             'label' => __('Image position', 'modularity'),
             'name' => 'image_position',
@@ -196,7 +225,7 @@
             'layout' => 'horizontal',
             'save_other_choice' => 0,
         ),
-        4 => array(
+        5 => array(
             'key' => 'field_628e0ffba7da4',
             'label' => __('Highlight first post', 'modularity'),
             'name' => 'posts_highlight_first',
@@ -265,7 +294,7 @@
             'ui_on_text' => '',
             'ui_off_text' => '',
         ),
-        5 => array(
+        6 => array(
             'key' => 'field_629f1b34ef9fc',
             'label' => __('Display highlighted post as', 'modularity'),
             'name' => 'posts_display_highlighted_as',
@@ -296,7 +325,7 @@
                 'block' => __('Block', 'modularity'),
                 'card' => __('Card', 'modularity'),
             ),
-            'default_value' => 'block',
+            'default_value' => __('block', 'modularity'),
             'return_format' => 'value',
             'multiple' => 0,
             'allow_null' => 0,
@@ -306,7 +335,7 @@
             'allow_custom' => 0,
             'search_placeholder' => '',
         ),
-        6 => array(
+        7 => array(
             'key' => 'field_571dfdf50d9da',
             'label' => __('Columns', 'modularity'),
             'name' => 'posts_columns',
@@ -376,7 +405,7 @@
                 'grid-md-4' => __('3', 'modularity'),
                 'grid-md-3' => __('4', 'modularity'),
             ),
-            'default_value' => 'grid-md-12',
+            'default_value' => __('grid-md-12', 'modularity'),
             'return_format' => 'value',
             'multiple' => 0,
             'allow_null' => 0,
@@ -386,7 +415,7 @@
             'allow_custom' => 0,
             'search_placeholder' => '',
         ),
-        7 => array(
+        8 => array(
             'key' => 'field_571e01e7f246c',
             'label' => __('Fields', 'modularity'),
             'name' => 'posts_fields',
@@ -421,10 +450,10 @@
                 'reading_time' => __('Show reading time', 'modularity'),
             ),
             'default_value' => array(
-                0 => 'date',
-                1 => 'excerpt',
-                2 => 'title',
-                3 => 'image',
+                0 => __('date', 'modularity'),
+                1 => __('excerpt', 'modularity'),
+                2 => __('title', 'modularity'),
+                3 => __('image', 'modularity'),
             ),
             'return_format' => 'value',
             'allow_custom' => 0,
@@ -433,7 +462,7 @@
             'save_custom' => 0,
             'custom_choice_button_text' => 'Lägg till nytt val',
         ),
-        8 => array(
+        9 => array(
             'key' => 'field_62387e4b55b75',
             'label' => __('Date source', 'modularity'),
             'name' => 'posts_date_source',
@@ -469,7 +498,7 @@
             'allow_custom' => 0,
             'search_placeholder' => '',
         ),
-        9 => array(
+        10 => array(
             'key' => 'field_591176fff96d6',
             'label' => __('Hide the title column', 'modularity'),
             'name' => 'posts_hide_title_column',
@@ -497,7 +526,7 @@
             'ui_on_text' => '',
             'ui_off_text' => '',
         ),
-        10 => array(
+        11 => array(
             'key' => 'field_57e3bcae3826e',
             'label' => __('Title column label', 'modularity'),
             'name' => 'title_column_label',
@@ -530,7 +559,7 @@
             'prepend' => '',
             'append' => '',
         ),
-        11 => array(
+        12 => array(
             'key' => 'field_571f5776592e6',
             'label' => __('List column labels', 'modularity'),
             'name' => 'posts_list_column_titles',
@@ -585,7 +614,7 @@
                 ),
             ),
         ),
-        12 => array(
+        13 => array(
             'key' => 'field_59197c6dafb31',
             'label' => __('Allow freetext filtering', 'modularity'),
             'name' => 'allow_freetext_filtering',
@@ -613,7 +642,7 @@
             'ui_on_text' => '',
             'ui_off_text' => '',
         ),
-        13 => array(
+        14 => array(
             'key' => 'field_5be480e163246',
             'label' => __('Highlight post', 'modularity'),
             'name' => 'posts_highlight',
@@ -641,7 +670,7 @@
             'ui_on_text' => __('Enabled', 'modularity'),
             'ui_off_text' => __('Disabled', 'modularity'),
         ),
-        14 => array(
+        15 => array(
             'key' => 'field_5bdb0d4217e91',
             'label' => __('Date format', 'modularity'),
             'name' => 'posts_date_format',
@@ -672,7 +701,7 @@
                 'default' => __('Default timestamp', 'modularity'),
                 'readable' => __('Readable timestamp', 'modularity'),
             ),
-            'default_value' => 'default',
+            'default_value' => __('default', 'modularity'),
             'allow_null' => 0,
             'multiple' => 0,
             'ui' => 0,
@@ -682,7 +711,7 @@
             'allow_custom' => 0,
             'search_placeholder' => '',
         ),
-        15 => array(
+        16 => array(
             'key' => 'field_5bd8575106176',
             'label' => __('Placeholder image', 'modularity'),
             'name' => 'posts_placeholder',
@@ -722,7 +751,7 @@
             'uploader' => '',
             'acfe_thumbnail' => 0,
         ),
-        16 => array(
+        17 => array(
             'key' => 'field_628e0f242aa5f',
             'label' => __('Ratio', 'modularity'),
             'name' => 'ratio',
@@ -756,7 +785,7 @@
                 '4:3' => __('4:3', 'modularity'),
                 '12:16' => __('12:16', 'modularity'),
             ),
-            'default_value' => '4:3',
+            'default_value' => __('4:3', 'modularity'),
             'allow_null' => 0,
             'multiple' => 0,
             'ui' => 0,

--- a/source/php/Module/Posts/TemplateController/ListTemplate.php
+++ b/source/php/Module/Posts/TemplateController/ListTemplate.php
@@ -40,15 +40,27 @@ class ListTemplate
         $list = [];
         if (!empty($this->data['posts']) && is_array($this->data['posts'])) {
             foreach ($this->data['posts'] as $post) {
-                if (!empty($post->postType) && $post->postType == 'attachment') {
-                    $link = wp_get_attachment_url($post->id);
+                if ($post->getPostType() === 'attachment') {
+                    $link = wp_get_attachment_url($post->getId());
                 } else {
-                    $link = $post->originalPermalink ?? $post->permalink;
+                    $link = $post->originalPermalink ?? $post->getPermalink();
                 }
-    
-                if (!empty($post->postTitle)) {
-                    array_push($list, ['link' => $link ?? '', 'title' => $post->postTitle]);
+
+                $listItem = [
+                    'link' => $link,
+                    'title' => $post->getTitle(),
+                    'icon' => 'arrow_forward',
+                ];
+
+                if(boolval(($this->data['meta']['use_term_icon_as_icon_in_list'] ?? false))) {
+                    $listItem['icon'] = !empty($post->getTermIcons()) ? [
+                            'icon' => $post->getTermIcons()[0]->getIcon(),
+                            'customColor' => $post->getTermIcons()[0]->getColor(),
+                            'size' => 'md'
+                    ] : 'arrow_forward';
                 }
+
+                $list[] = $listItem;
             }
         }
 

--- a/source/php/Module/Posts/views/list.blade.php
+++ b/source/php/Module/Posts/views/list.blade.php
@@ -23,7 +23,7 @@
                             @if ($post['link'] && $post['title'])
                                 @collection__item([
                                     'displayIcon' => true,
-                                    'icon' => 'arrow_forward',
+                                    'icon' => $post['icon'],
                                     'link' => $post['link']
                                 ])
                                     @typography([


### PR DESCRIPTION
This pull request introduces a new feature to use term icons as icons in post lists and includes several improvements and refactorings in the `mod-posts-displau` module. The most important changes include adding a new field for the term icon feature, updating default values to use translations, and refactoring code for better readability and consistency.

### New Feature:
* Added a new field `use_term_icon_as_icon_in_list` to enable using term icons as icons in the post list. This field is a true/false type and is conditionally displayed based on the value of another field. (`source/php/AcfFields/json/mod-posts-displau.json`, `source/php/AcfFields/php/mod-posts-displau.php`) [[1]](diffhunk://#diff-5ff23a5049c7632ad5a52728c14e63be0972ccbb2beb1bb2c36259e44e575958R37-R65) [[2]](diffhunk://#diff-a356ad5a24957b44ed09c1b2a28a8c2c93f9e5270657d3b21619033644df4cb2L33-R69)

### Code Refactoring:
* Updated the `prepare` method in `ListTemplate.php` to use getter methods for post properties and added logic to handle the new term icon feature. (`source/php/Module/Posts/TemplateController/ListTemplate.php`)
* Modified the `list.blade.php` view to use the dynamic icon from the post data. (`source/php/Module/Posts/views/list.blade.php`)

### Default Values:
* Updated default values for several fields to use the translation function `__()` for better localization support. (`source/php/AcfFields/php/mod-posts-displau.php`) [[1]](diffhunk://#diff-a356ad5a24957b44ed09c1b2a28a8c2c93f9e5270657d3b21619033644df4cb2L299-R328) [[2]](diffhunk://#diff-a356ad5a24957b44ed09c1b2a28a8c2c93f9e5270657d3b21619033644df4cb2L379-R408) [[3]](diffhunk://#diff-a356ad5a24957b44ed09c1b2a28a8c2c93f9e5270657d3b21619033644df4cb2L424-R456) [[4]](diffhunk://#diff-a356ad5a24957b44ed09c1b2a28a8c2c93f9e5270657d3b21619033644df4cb2L675-R704) [[5]](diffhunk://#diff-a356ad5a24957b44ed09c1b2a28a8c2c93f9e5270657d3b21619033644df4cb2L759-R788)

### Field Reordering:
* Reordered the fields in `mod-posts-displau.php` to maintain the correct sequence after adding the new term icon field. (`source/php/AcfFields/php/mod-posts-displau.php`) [[1]](diffhunk://#diff-a356ad5a24957b44ed09c1b2a28a8c2c93f9e5270657d3b21619033644df4cb2L103-R132) [[2]](diffhunk://#diff-a356ad5a24957b44ed09c1b2a28a8c2c93f9e5270657d3b21619033644df4cb2L166-R195) [[3]](diffhunk://#diff-a356ad5a24957b44ed09c1b2a28a8c2c93f9e5270657d3b21619033644df4cb2L199-R228) [[4]](diffhunk://#diff-a356ad5a24957b44ed09c1b2a28a8c2c93f9e5270657d3b21619033644df4cb2L268-R297) [[5]](diffhunk://#diff-a356ad5a24957b44ed09c1b2a28a8c2c93f9e5270657d3b21619033644df4cb2L309-R338) [[6]](diffhunk://#diff-a356ad5a24957b44ed09c1b2a28a8c2c93f9e5270657d3b21619033644df4cb2L389-R418) [[7]](diffhunk://#diff-a356ad5a24957b44ed09c1b2a28a8c2c93f9e5270657d3b21619033644df4cb2L436-R465) [[8]](diffhunk://#diff-a356ad5a24957b44ed09c1b2a28a8c2c93f9e5270657d3b21619033644df4cb2L500-R529) [[9]](diffhunk://#diff-a356ad5a24957b44ed09c1b2a28a8c2c93f9e5270657d3b21619033644df4cb2L533-R562) [[10]](diffhunk://#diff-a356ad5a24957b44ed09c1b2a28a8c2c93f9e5270657d3b21619033644df4cb2L588-R617) [[11]](diffhunk://#diff-a356ad5a24957b44ed09c1b2a28a8c2c93f9e5270657d3b21619033644df4cb2L616-R645) [[12]](diffhunk://#diff-a356ad5a24957b44ed09c1b2a28a8c2c93f9e5270657d3b21619033644df4cb2L644-R673) [[13]](diffhunk://#diff-a356ad5a24957b44ed09c1b2a28a8c2c93f9e5270657d3b21619033644df4cb2L685-R714) [[14]](diffhunk://#diff-a356ad5a24957b44ed09c1b2a28a8c2c93f9e5270657d3b21619033644df4cb2L725-R754)