### PR TITLE
feat: upgrade for modules missing content

### DIFF
--- a/source/php/Upgrade.php
+++ b/source/php/Upgrade.php
@@ -61,7 +61,6 @@ class Upgrade
      */
     public function upgrade()
     {
-
         if (empty(get_option($this->dbVersionKey))) {
             update_option($this->dbVersionKey, 0);
         }

--- a/source/php/Upgrade.php
+++ b/source/php/Upgrade.php
@@ -39,7 +39,7 @@ class Upgrade
      */
     public function reset()
     {
-        update_option($this->dbVersionKey, 7);
+        update_option($this->dbVersionKey, 0);
     }
 
     /**
@@ -61,8 +61,6 @@ class Upgrade
      */
     public function upgrade()
     {
-
-        $this->reset();
 
         if (empty(get_option($this->dbVersionKey))) {
             update_option($this->dbVersionKey, 0);

--- a/source/php/Upgrade.php
+++ b/source/php/Upgrade.php
@@ -11,7 +11,7 @@ use WP_CLI;
  */
 class Upgrade
 {
-    private $dbVersion = 7;
+    private $dbVersion = 8;
     private $dbVersionKey = 'modularity_db_version';
     private $db;
 

--- a/source/php/Upgrade.php
+++ b/source/php/Upgrade.php
@@ -39,7 +39,7 @@ class Upgrade
      */
     public function reset()
     {
-        update_option($this->dbVersionKey, 0);
+        update_option($this->dbVersionKey, 7);
     }
 
     /**
@@ -61,6 +61,9 @@ class Upgrade
      */
     public function upgrade()
     {
+
+        $this->reset();
+
         if (empty(get_option($this->dbVersionKey))) {
             update_option($this->dbVersionKey, 0);
         }

--- a/source/php/Upgrade/Migrators/Module/AcfModuleRepeaterFieldsMigrator.php
+++ b/source/php/Upgrade/Migrators/Module/AcfModuleRepeaterFieldsMigrator.php
@@ -39,7 +39,7 @@ class AcfModuleRepeaterFieldsMigrator implements MigratorInterface {
                 $oldSubFieldValue = isset($this->oldFieldValue[$i - 1][$oldFieldName]) ? 
                 $this->oldFieldValue[$i - 1][$oldFieldName] : 
                 false;
-
+                
                 if (!empty($oldSubFieldValue)) {
                     $fieldWasUpdated = update_sub_field([$this->newField['name'], $i, $newFieldName], $oldSubFieldValue, $this->moduleId);
                 }

--- a/source/php/Upgrade/Migrators/Module/AcfModuleRepeaterFieldsMigrator.php
+++ b/source/php/Upgrade/Migrators/Module/AcfModuleRepeaterFieldsMigrator.php
@@ -39,6 +39,8 @@ class AcfModuleRepeaterFieldsMigrator implements MigratorInterface {
                 $oldSubFieldValue = isset($this->oldFieldValue[$i - 1][$oldFieldName]) ? 
                 $this->oldFieldValue[$i - 1][$oldFieldName] : 
                 false;
+
+                var_dump($oldSubFieldValue);
                 
                 if (!empty($oldSubFieldValue)) {
                     update_sub_field([$this->newField['name'], $i, $newFieldName], $oldSubFieldValue, $this->moduleId);

--- a/source/php/Upgrade/Migrators/Module/AcfModuleRepeaterFieldsMigrator.php
+++ b/source/php/Upgrade/Migrators/Module/AcfModuleRepeaterFieldsMigrator.php
@@ -40,11 +40,8 @@ class AcfModuleRepeaterFieldsMigrator implements MigratorInterface {
                 $this->oldFieldValue[$i - 1][$oldFieldName] : 
                 false;
 
-                var_dump($oldSubFieldValue);
-                
                 if (!empty($oldSubFieldValue)) {
-                    update_sub_field([$this->newField['name'], $i, $newFieldName], $oldSubFieldValue, $this->moduleId);
-                    $fieldWasUpdated = true;
+                    $fieldWasUpdated = update_sub_field([$this->newField['name'], $i, $newFieldName], $oldSubFieldValue, $this->moduleId);
                 }
             }
         }

--- a/source/php/Upgrade/Version/V8.php
+++ b/source/php/Upgrade/Version/V8.php
@@ -65,6 +65,16 @@ class V8 implements versionInterface {
           $this->db->query($subQuery);
         }
       }
+
+      /* Update how many rows that have been migrated */
+      $query = $this->db->prepare(
+          "SELECT COUNT(*) 
+          FROM {$this->db->prefix}postmeta 
+          WHERE post_id = %d AND meta_key LIKE ",
+          $module->ID,
+        ) . "'{$this->newKey}_%_title'";
+      update_post_meta($module->ID, 'manual_inputs', $this->db->get_var($query) ?? 0);
+    
       return true;
     }
 

--- a/source/php/Upgrade/Version/V8.php
+++ b/source/php/Upgrade/Version/V8.php
@@ -46,22 +46,27 @@ class V8 implements versionInterface {
           'fields' => [
             'post_title' => 'title',
             'post_content' => 'content',
+            'permalink' => 'permalink',
+            'image' => 'image',
+            'column_values' => 'accordion_column_values',
           ]
         ];
         $migrator = new AcfModuleRepeaterFieldsMigrator($newField, $oldFieldValue, $module->ID);
         $migrator->migrate();
 
-
-        var_dump($module->ID, get_field($this->newKey, $module->ID));
-
-
-
-        break;
-
-
+        break; // Test one module at a time
       }
     }
 
+    /**
+     * A version of get_field that can handle fields that are not defined in ACF
+     * @supports: repeater fields
+     * 
+     * @param int $postId
+     * @param string $fieldKey
+     * 
+     * @return array
+     */
     private function getUndefinedField($postId, $fieldKey) {
       $query = $this->db->prepare(
         "SELECT * FROM {$this->db->postmeta} WHERE post_id = %d AND meta_key LIKE ",

--- a/source/php/Upgrade/Version/V8.php
+++ b/source/php/Upgrade/Version/V8.php
@@ -67,13 +67,13 @@ class V8 implements versionInterface {
       }
 
       /* Update how many rows that have been migrated */
-      $query = $this->db->prepare(
+      $numberOfRowsQuery = $this->db->prepare(
           "SELECT COUNT(*) 
           FROM {$this->db->prefix}postmeta 
           WHERE post_id = %d AND meta_key LIKE ",
           $module->ID,
         ) . "'{$this->newKey}_%_title'";
-      update_post_meta($module->ID, 'manual_inputs', $this->db->get_var($query) ?? 0);
+      update_post_meta($module->ID, 'manual_inputs', $this->db->get_var($numberOfRowsQuery) ?? 0);
     
       return true;
     }

--- a/source/php/Upgrade/Version/V8.php
+++ b/source/php/Upgrade/Version/V8.php
@@ -73,7 +73,7 @@ class V8 implements versionInterface {
           WHERE post_id = %d AND meta_key LIKE ",
           $module->ID,
         ) . "'{$this->newKey}_%_title'";
-      update_post_meta($module->ID, 'manual_inputs', $this->db->get_var($numberOfRowsQuery) ?? 0);
+      update_post_meta($module->ID, $this->newKey, $this->db->get_var($numberOfRowsQuery) ?? 0);
     
       return true;
     }

--- a/source/php/Upgrade/Version/V8.php
+++ b/source/php/Upgrade/Version/V8.php
@@ -46,15 +46,15 @@ class V8 implements versionInterface {
           "UPDATE {$this->db->prefix}postmeta 
           SET meta_key = REPLACE(meta_key, %s, %s) 
           WHERE post_id = %d AND meta_key ",
-          $this->oldKey,  // The part to replace
-          $this->newKey,  // The new value to replace it with
+          $this->oldKey,
+          $this->newKey,
           $module->ID,
         ) . "LIKE '%{$this->oldKey}%'";
         $this->db->query($query);
 
         /* Updates suffix */ 
         foreach(['_post_title' => '_title', '_post_content' => '_content'] as $old => $new) {
-          $subQuery = $query = $this->db->prepare(
+          $subQuery = $this->db->prepare(
             "UPDATE {$this->db->prefix}postmeta 
             SET meta_key = REPLACE(meta_key, %s, %s) 
             WHERE post_id = %d AND meta_key ",

--- a/source/php/Upgrade/Version/V8.php
+++ b/source/php/Upgrade/Version/V8.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Modularity\Upgrade\Version;
+
+use \Modularity\Upgrade\Version\Helper\GetPostsByPostType;
+
+/**
+ * Class V8
+ * This version migrates really old posts modules that have previously been migrated to manualinput in the V5 upgrade.
+ * Due to the old structure, this was not done properly and the data is not correctly migrated.
+ * 
+ * @package Modularity\Upgrade\Version
+ */
+
+class V8 implements versionInterface {
+    private $db;
+    private $oldKey = 'data';
+    private $newKey = 'manual_inputs';
+
+    public function __construct(\wpdb $db) {
+      $this->db = $db;
+    }
+
+    public function upgrade(): bool
+    {
+      $this->upgradeModules();
+      return true;
+    }
+
+    /**
+     * Migrate modules from old key to new key
+     * 
+     * @return bool
+     */
+    private function upgradeModules() 
+    {
+      $modulesMatchingCriteria = $this->getModules(); 
+
+      if(empty($modulesMatchingCriteria)) {
+        return false;
+      }
+
+      foreach ($modulesMatchingCriteria as $module) {
+        /* Update prefix */ 
+        $query = $this->db->prepare(
+          "UPDATE {$this->db->prefix}postmeta 
+          SET meta_key = REPLACE(meta_key, %s, %s) 
+          WHERE post_id = %d AND meta_key ",
+          $this->oldKey,  // The part to replace
+          $this->newKey,  // The new value to replace it with
+          $module->ID,
+        ) . "LIKE '%{$this->oldKey}%'";
+        $this->db->query($query);
+
+        /* Updates suffix */ 
+        foreach(['_post_title' => '_title', '_post_content' => '_content'] as $old => $new) {
+          $subQuery = $query = $this->db->prepare(
+            "UPDATE {$this->db->prefix}postmeta 
+            SET meta_key = REPLACE(meta_key, %s, %s) 
+            WHERE post_id = %d AND meta_key ",
+            $old,  
+            $new,
+            $module->ID,
+          ) . "LIKE '%{$this->newKey}%{$old}%'";
+          $this->db->query($subQuery);
+        }
+      }
+      return true;
+    }
+
+    /**
+     * Get modules that should be migrated. We assume that all 
+     * manualinput modules that does not have any data in the 
+     * manual_inputs field should be migrated.
+     * 
+     * @return array
+     */
+    private function getModules(): array 
+    {
+        $postsModules = GetPostsByPostType::getPostsByPostType('mod-manualinput');
+
+        //Get modules that does not have any data in the manual_inputs field
+        $filteredPostsModules = array_filter($postsModules, function ($module) {
+            if (!empty($module->ID)) {
+                $dataInList = get_field($this->newKey, $module->ID);
+                return empty($dataInList);
+            }
+            return false;
+        });
+        return $filteredPostsModules ?? [];
+    }
+
+}

--- a/source/php/Upgrade/Version/V8.php
+++ b/source/php/Upgrade/Version/V8.php
@@ -36,8 +36,12 @@ class V8 implements versionInterface {
     private function upgradeModules() 
     {
       $modulesMatchingCriteria = $this->getModules(); 
-      foreach ($modulesMatchingCriteria as $module) {
 
+      if (empty($modulesMatchingCriteria)) {
+        return;
+      }
+
+      foreach ($modulesMatchingCriteria as $module) {
         $oldFieldValue = $this->getUndefinedField($module->ID, $this->oldKey);
 
         $newField = [
@@ -47,14 +51,13 @@ class V8 implements versionInterface {
             'post_title' => 'title',
             'post_content' => 'content',
             'permalink' => 'permalink',
+            'permalink' => 'link',
             'image' => 'image',
             'column_values' => 'accordion_column_values',
           ]
         ];
         $migrator = new AcfModuleRepeaterFieldsMigrator($newField, $oldFieldValue, $module->ID);
         $migrator->migrate();
-
-        break; // Test one module at a time
       }
     }
 


### PR DESCRIPTION
This pull request introduces a new upgrade version for the database schema and includes changes to handle the migration of old post modules. The most important changes involve updating the database version and adding a new class to manage the migration process.

Database version update:

* [`source/php/Upgrade.php`](diffhunk://#diff-126f7336ececf01562d4dc2fd784a150414750cccc75c64d722c8944f039d0e1L14-R14): Updated the `dbVersion` from 7 to 8.

Migration process for old post modules:

* [`source/php/Upgrade/Version/V8.php`](diffhunk://#diff-1f1fb32a4d9a2d31da4bd10c33a08fcaef42ae247d5dcc4ac5c1a47a6a909c19R1-R93): Added a new class `V8` that implements the `versionInterface` to handle the migration of old post modules to the new structure. This class includes methods to upgrade modules and retrieve modules that need migration.