### PR TITLE
feat: add slideHasLink method and corresponding tests for link validation

### DIFF
--- a/source/php/Module/Slider/Slider.php
+++ b/source/php/Module/Slider/Slider.php
@@ -202,7 +202,8 @@ class Slider extends \Modularity\Module
      * @return array
      */
     private function getLinkData(array $slide) {
-        if (empty($slide['link_url'])) {
+
+        if(!$this->slideHasLink($slide)) {
             return $slide;
         }
 
@@ -226,6 +227,24 @@ class Slider extends \Modularity\Module
         }
 
         return $slide;
+    }
+
+    /**
+     * Check if slide has link
+     * 
+     * @param array $slide
+     * @return bool
+     */
+    public function slideHasLink(array $slide):bool {
+        if( $slide['link_type'] !== 'internal' && $slide['link_type'] !== 'external' ) {
+            return false;
+        }
+
+        if( empty($slide['link_url']) ) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/source/php/Module/Slider/Slider.test.php
+++ b/source/php/Module/Slider/Slider.test.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Modularity\Module\Slider;
+
+use PHPUnit\Framework\TestCase;
+
+class SliderTest extends TestCase {
+    
+    /**
+     * @testdox class can be instantiated
+     */
+    public function testClassCanBeInstantiated() {
+        $slider = new Slider();
+        $this->assertInstanceOf(Slider::class, $slider);
+    }
+
+    /**
+     * @testdox slideHasLink returns false if link_type is not internal or external
+     */
+    public function testSlideHasLinkReturnFalseIfLinkTypeIndicatesNoLink() {
+        $slider = new Slider();
+        $linkUrl = 'https://example.com';
+        $this->assertFalse($slider->slideHasLink([ 'link_type' => 'false', 'link_url' => $linkUrl ]));
+    }
+
+    /**
+     * @testdox slideHasLink returns false if link_url is empty
+     */
+    public function testSlideHasLinkReturnFalseIfLinkUrlIsEmpty() {
+        $slider = new Slider();
+        $this->assertFalse($slider->slideHasLink([ 'link_type' => 'internal', 'link_url' => '' ]));
+    }
+
+    /**
+     * @testdox slideHasLink returns true if link_type is internal and link_url is not empty
+     */
+    public function testSlideHasLinkReturnTrueIfLinkTypeIsInternalAndLinkUrlIsNotEmpty() {
+        $slider = new Slider();
+        $linkUrl = 'https://example.com';
+        $this->assertTrue($slider->slideHasLink([ 'link_type' => 'internal', 'link_url' => $linkUrl ]));
+    }
+}


### PR DESCRIPTION
This pull request introduces a new method to check if a slide has a link and adds corresponding unit tests to ensure the method works correctly. The main changes include modifying the `getLinkData` method to use the new `slideHasLink` method and adding a new test class for the `Slider` module.

### Enhancements to link checking:

* [`source/php/Module/Slider/Slider.php`](diffhunk://#diff-27d39ddc53c1fa6f01d6a17ba7268c0c4d778f1694a1bc25a71375c483f22156L205-R206): Added a new method `slideHasLink` to check if a slide has a valid link and updated the `getLinkData` method to use this new method. [[1]](diffhunk://#diff-27d39ddc53c1fa6f01d6a17ba7268c0c4d778f1694a1bc25a71375c483f22156L205-R206) [[2]](diffhunk://#diff-27d39ddc53c1fa6f01d6a17ba7268c0c4d778f1694a1bc25a71375c483f22156R232-R249)

### Unit tests:

* [`source/php/Module/Slider/Slider.test.php`](diffhunk://#diff-3e52994b2788c1c9f3bb2f5b74650347a006d31882bfa2db47075465c671176bR1-R42): Added a new test class `SliderTest` with multiple test cases to verify the functionality of the `slideHasLink` method.