### PR TITLE
fix: handle null posts array in AbstractController

### DIFF
--- a/source/php/Module/Posts/TemplateController/AbstractController.php
+++ b/source/php/Module/Posts/TemplateController/AbstractController.php
@@ -96,7 +96,7 @@ class AbstractController
             
             return $post;
 
-        }, $posts);
+        }, $posts ?? []);
 
         if(!empty($posts)) {
             foreach ($posts as $index => &$post) {


### PR DESCRIPTION
This pull request includes a small change to the `source/php/Module/Posts/TemplateController/AbstractController.php` file. The change ensures that the `preparePosts` function handles a null value for the `$posts` parameter by providing a default empty array.

* [`source/php/Module/Posts/TemplateController/AbstractController.php`](diffhunk://#diff-980419417ddbc5e348ccc543ee9c4cdf01e82b3e271f1b3c95ec5c3571dae4e8L99-R99): Updated the `preparePosts` function to use the null coalescing operator for the `$posts` parameter to ensure it defaults to an empty array if null.