### PR TITLE
fix: added a check to ensure that only super admins will see upgrade info

### DIFF
--- a/source/php/Upgrade.php
+++ b/source/php/Upgrade.php
@@ -22,6 +22,10 @@ class Upgrade
 
     public function addAdminNotice() 
     {
+        if (!is_super_admin()) {
+            return;
+        }
+
         $currentDbVersion = get_option($this->dbVersionKey);
         if (empty($currentDbVersion) || $currentDbVersion < $this->dbVersion) {
             echo sprintf(


### PR DESCRIPTION
* [`source/php/Upgrade.php`](diffhunk://#diff-126f7336ececf01562d4dc2fd784a150414750cccc75c64d722c8944f039d0e1R25-R28): Added a check to ensure that only super admins can proceed with the `addAdminNotice` function by returning early if the user is not a super admin.