### PR TITLE
fix: remove options that allow user to create ugly UI.

### DIFF
--- a/source/php/AcfFields/json/mod-manual-input.json
+++ b/source/php/AcfFields/json/mod-manual-input.json
@@ -148,34 +148,6 @@
             "ui": 1
         },
         {
-            "key": "field_67f666d7dd2a1",
-            "label": "Title as heading",
-            "name": "accordion_heading_title",
-            "aria-label": "",
-            "type": "true_false",
-            "instructions": "Title will be displayed as heading instead of card header",
-            "required": 0,
-            "conditional_logic": [
-                [
-                    {
-                        "field": "field_6752f959acfda",
-                        "operator": "==",
-                        "value": "accordion"
-                    }
-                ]
-            ],
-            "wrapper": {
-                "width": "",
-                "class": "",
-                "id": ""
-            },
-            "message": "",
-            "default_value": 0,
-            "ui_on_text": "",
-            "ui_off_text": "",
-            "ui": 1
-        },
-        {
             "key": "field_67f66637f8734",
             "label": "Spaced sections",
             "name": "accordion_spaced_sections",

--- a/source/php/AcfFields/php/mod-manual-input.php
+++ b/source/php/AcfFields/php/mod-manual-input.php
@@ -152,34 +152,6 @@ if (function_exists('acf_add_local_field_group')) {
             'ui_off_text' => '',
             'ui' => 1,
         ),
-        5 => array(
-            'key' => 'field_67f666d7dd2a1',
-            'label' => __('Title as heading', 'modularity'),
-            'name' => 'accordion_heading_title',
-            'aria-label' => '',
-            'type' => 'true_false',
-            'instructions' => __('Title will be displayed as heading instead of card header', 'modularity'),
-            'required' => 0,
-            'conditional_logic' => array(
-                0 => array(
-                    0 => array(
-                        'field' => 'field_6752f959acfda',
-                        'operator' => '==',
-                        'value' => 'accordion',
-                    ),
-                ),
-            ),
-            'wrapper' => array(
-                'width' => '',
-                'class' => '',
-                'id' => '',
-            ),
-            'message' => '',
-            'default_value' => 0,
-            'ui_on_text' => '',
-            'ui_off_text' => '',
-            'ui' => 1,
-        ),
         6 => array(
             'key' => 'field_67f66637f8734',
             'label' => __('Spaced sections', 'modularity'),

--- a/source/php/Module/ManualInput/ManualInput.php
+++ b/source/php/Module/ManualInput/ManualInput.php
@@ -59,7 +59,6 @@ class ManualInput extends \Modularity\Module
 
         // Accordion settings
         if ($fields['display_as'] === 'accordion') {
-            $data['accordionHeadingTitle'] = $fields['accordion_heading_title'] ?? false;
             $data['accordionSpacedSections'] = $fields['accordion_spaced_sections'] ?? false;
         }
 

--- a/source/php/Module/ManualInput/views/accordion.blade.php
+++ b/source/php/Module/ManualInput/views/accordion.blade.php
@@ -1,4 +1,4 @@
-@if ($accordionHeadingTitle)
+@if (empty($hideTitle) && !empty($postTitle) && $accordionSpacedSections)
     <div class="u-margin__bottom--2">
         @include('partials.post-title', ['variant' => 'h2', 'classList' => []])
     </div>
@@ -7,7 +7,7 @@
     @card([
         'context' => $context
     ])
-        @if (empty($hideTitle) && !empty($postTitle) && !$accordionHeadingTitle)
+        @if (empty($hideTitle) && !empty($postTitle) && !$accordionSpacedSections)
             <div class="c-card__header">
                 @include('partials.post-title', ['variant' => 'h4', 'classList' => []])
             </div>


### PR DESCRIPTION
This pull request includes changes to the `source/php/Module/ManualInput` module to remove the "Title as heading" feature and update the related logic. The most important changes include removing the field definition for "Title as heading" and updating the conditional logic in the `accordion.blade.php` view file.

Removal of "Title as heading" feature:

* [`source/php/AcfFields/json/mod-manual-input.json`](diffhunk://#diff-0b424789c17273fa038000a7d2acdcf33d3ce674d8bf35aa8f5fe0adc362124bL150-L177): Removed the "Title as heading" field definition.
* [`source/php/AcfFields/php/mod-manual-input.php`](diffhunk://#diff-6c60b6a8d7a5aa3e94b9ce98b64215191c9a0faedbbeeec7ad14ee5ffeb37b64L155-L182): Removed the "Title as heading" field configuration.
* [`source/php/Module/ManualInput/ManualInput.php`](diffhunk://#diff-5531c22c63458e7046845d21e1bd226b075d627ed08e0590aa6e9e47dc964ea1L62): Removed the assignment of `accordionHeadingTitle` in the `data` method.

Updates to conditional logic:

* [`source/php/Module/ManualInput/views/accordion.blade.php`](diffhunk://#diff-1ed3cd1e008f89a7594787c189d48b44e6664cc7a0e8b838afdceb8fc9ef3222L1-R1): Updated the conditional logic to use `accordionSpacedSections` instead of `accordionHeadingTitle`. [[1]](diffhunk://#diff-1ed3cd1e008f89a7594787c189d48b44e6664cc7a0e8b838afdceb8fc9ef3222L1-R1) [[2]](diffhunk://#diff-1ed3cd1e008f89a7594787c189d48b44e6664cc7a0e8b838afdceb8fc9ef3222L10-R10)