### PR TITLE
Fix/inline shortcodes

### DIFF
--- a/source/php/Module/Text/Text.php
+++ b/source/php/Module/Text/Text.php
@@ -16,24 +16,30 @@ class Text extends \Modularity\Module
 
     public function data() : array
     {
-        $data = $this->getFields(); 
+        $data = $this->getFields() ?? []; 
 
-        if (empty($data['post_content']) && !empty($data['content'])) {
-            $data['post_content'] = $data['content'];
+        // Check if module is in inline mode
+        $isInline = (bool) $this->args['inline'] ?? false;
+
+        // Post content [with multiple fallbacks]
+        $data['postContent'] = $this->data['post_content'] ?? $data['post_content'] ?: $data['content'] ?? '';
+
+        //Run relevant filters
+        foreach(['Modularity/Display/SanitizeContent', 'the_content'] as $filter) {
+            if($filter === 'the_content' && $isInline) {
+                continue;
+            }
+            $data['postContent'] = apply_filters($filter, $data['postContent']);
         }
 
         // Check if content contains h1-h6 tags
         $data['hasHeadingsInContent'] = preg_match('/<h[1-6]/', $data['post_content'] ?? '');
 
-        if (empty($this->ID)) {
-            $data['ID'] = uniqid();
-        }
+        // Alway set ID
+        $data['ID'] = $data['ID'] ?? uniqid();
 
-        if(is_array($data)) {
-            return $data; 
-        }
-        
-        return [];
+        // Set default values
+        return $data ?? []; 
     }
     
     public function template()

--- a/source/php/Module/Text/views/article.blade.php
+++ b/source/php/Module/Text/views/article.blade.php
@@ -5,7 +5,6 @@
         ...(!$hideTitle && !empty($postTitle) ? ['aria-labelledby' => 'mod-text-' . $ID . '-label'] : []),
     ]
 ])
-    
     @if (!$hideTitle && !empty($postTitle))
         @typography([
                 "element" => "h2",
@@ -15,6 +14,8 @@
                 {!! $postTitle !!}
         @endtypography
     @endif
-    
-    {!! apply_filters('the_content', apply_filters('Modularity/Display/SanitizeContent', $post_content)) !!}
+
+    @if($postContent)
+        {!! $postContent !!}
+    @endif
 @endelement

--- a/source/php/Module/Text/views/box.blade.php
+++ b/source/php/Module/Text/views/box.blade.php
@@ -15,7 +15,10 @@
             @endtypography
         </div>
     @endif
-    <div class="c-card__body">
-        {!! apply_filters('the_content', apply_filters('Modularity/Display/SanitizeContent', $post_content)) !!}
-    </div>
+    
+    @if($postContent)
+        <div class="c-card__body">
+            {!! $postContent !!}
+        </div>
+    @endif
 @endcard

--- a/source/php/ModuleManager.php
+++ b/source/php/ModuleManager.php
@@ -411,23 +411,8 @@ class ModuleManager
             echo '<p>';
             echo __('Copy and paste this shortcode to display the module inline.', 'modularity');
             echo '</p><p>';
-            echo '<label><input type="checkbox" class="modularity-inline-template" checked> Use inline template</label>';
             echo '<textarea style="margin-top:10px; overflow: hidden;width: 100%;height:30px;background:#f9f9f9;border:1px solid #ddd;padding:5px;">[modularity id="' . $post->ID . '"]</textarea>';
             echo '</p>';
-
-            echo "<script>
-                jQuery(document).ready(function ($) {
-                    $('.modularity-inline-template').prop('checked', true);
-
-                    $('.modularity-inline-template').on('change', function () {
-                        if ($(this).prop('checked') == false) {
-                            $(this).parents('.inside').find('pre span').text(' inline=\"false\"');
-                        } else {
-                            $(this).parents('.inside').find('pre span').text('');
-                        }
-                    });
-                });
-            </script>";
         }, self::$enabled, 'side', 'default');
     }
 


### PR DESCRIPTION
This pull request refactors the `Text` module to improve content handling, enhance flexibility, and clean up unused code. The most significant changes include introducing a new `postContent` property with multiple fallbacks and filters, updating Blade templates to use the new property, and removing unused inline template functionality.

### Content Handling Improvements:
* [`source/php/Module/Text/Text.php`](diffhunk://#diff-0909ca5daa6263ccd7a30e5124c5f89fc10f80e83382c5a2fd5b6b94f9769294L19-R42): Introduced a new `postContent` property with multiple fallbacks and applied filters conditionally based on the `inline` mode. This ensures better content sanitization and flexibility. Additionally, the `ID` is always set, and default values are returned for the data array.

### Blade Template Updates:
* [`source/php/Module/Text/views/article.blade.php`](diffhunk://#diff-0d52697a49b931d97876677617ed249e1153d4058efda6d4ba16f885c4eb58ebL19-R20): Updated to use the new `postContent` property instead of directly applying filters on `post_content`. Added a conditional check to render `postContent` only if it exists.
* [`source/php/Module/Text/views/box.blade.php`](diffhunk://#diff-a9c57e5c09d7aa1c133cecf96d21bf250352d2cacba4f4c20ec0d61cd692a9c9R18-R23): Similarly updated to render `postContent` conditionally, improving consistency across templates.

### Code Cleanup:
* [`source/php/ModuleManager.php`](diffhunk://#diff-32f0edd887abe805eeaef2123e64b796189f390a9ba60d03cb33a82e165c4f33L414-L430): Removed unused inline template checkbox and related JavaScript, simplifying the shortcode metabox UI.