### PR TITLE
fix: create unique cache groups on get params.

### DIFF
--- a/source/php/Display.php
+++ b/source/php/Display.php
@@ -478,7 +478,7 @@ class Display
                 $args['id']
             ], 
             $moduleSettings['cache_ttl'] ?? 0,
-            $_GET ?? null
+            $this->getRegisteredQueryVars() ?? null
         );
 
         if ($echo == false) {
@@ -503,6 +503,22 @@ class Display
         }
 
         return true;
+    }
+
+    /**
+     * Get registered query vars
+     * @return array
+     */
+    private function getRegisteredQueryVars(): array
+    {
+        global $wp;
+        $result = [];
+        if (isset($wp->public_query_vars) && is_array($wp->public_query_vars)) {
+            foreach ($wp->public_query_vars as $var) {
+                $result[$var] = get_query_var($var);
+            }
+        }
+        return $result;
     }
 
     /**

--- a/source/php/Display.php
+++ b/source/php/Display.php
@@ -478,7 +478,7 @@ class Display
                 $args['id']
             ], 
             $moduleSettings['cache_ttl'] ?? 0,
-            $this->getRegisteredQueryVars() ?? null
+            $this->getRegisteredQueryVars() ?: null
         );
 
         if ($echo == false) {
@@ -518,7 +518,7 @@ class Display
                 $result[$var] = get_query_var($var);
             }
         }
-        return $result;
+        return array_filter($result);
     }
 
     /**

--- a/source/php/Display.php
+++ b/source/php/Display.php
@@ -477,7 +477,8 @@ class Display
                 $module, 
                 $args['id']
             ], 
-            $moduleSettings['cache_ttl'] ?? 0
+            $moduleSettings['cache_ttl'] ?? 0,
+            $_GET ?? null
         );
 
         if ($echo == false) {

--- a/source/php/Helper/Cache.php
+++ b/source/php/Helper/Cache.php
@@ -54,7 +54,7 @@ class Cache
 
             $roleHash = $this->createShortHash($caps, true);
             if ($roleHash !== false) {
-                $this->hash = $this->hash . "-auth-" . $roleHash . "-" . $cacheGroup;
+                $this->hash = $this->hash . "-auth-" . $roleHash;
             }
         }
 

--- a/source/php/Helper/Cache.php
+++ b/source/php/Helper/Cache.php
@@ -9,7 +9,7 @@ class Cache
      * @param  string $postId      The post id that you want to cache (or any other key that relates to specific data)
      * @param  string $module      Any input data altering output result as a concatinated string/array/object.
      * @param  string $ttl         The time that a cache should live (in seconds),
-     * @param  string $cacheGroup    The cache key to use, if not set it will use the postId as key
+     * @param  mixed  $cacheGroup  The value to create a short hash from, to create a unique cache group.
      * @return string              The request response
      */
 

--- a/source/php/Helper/Cache.php
+++ b/source/php/Helper/Cache.php
@@ -8,7 +8,8 @@ class Cache
      * Fragment cache in object cache
      * @param  string $postId      The post id that you want to cache (or any other key that relates to specific data)
      * @param  string $module      Any input data altering output result as a concatinated string/array/object.
-     * @param  string $ttl         The time that a cache should live (in seconds)
+     * @param  string $ttl         The time that a cache should live (in seconds),
+     * @param  string $cacheGroup    The cache key to use, if not set it will use the postId as key
      * @return string              The request response
      */
 
@@ -18,8 +19,15 @@ class Cache
 
     public $keyGroup = 'modules';
 
-    public function __construct($postId, $module = '', $ttl = 3600*24)
+    public function __construct($postId, $module = '', $ttl = 3600*24, $cacheGroup = null)
     {
+        // Create cache group hash
+        if(!is_null($cacheGroup)) {
+            $cacheGroup = $this->createShortHash($cacheGroup);
+        } else {
+            $cacheGroup = '';
+        }
+
         // Set variables
         $this->postId       = $postId;
         $this->ttl          = $ttl;
@@ -46,8 +54,12 @@ class Cache
 
             $roleHash = $this->createShortHash($caps, true);
             if ($roleHash !== false) {
-                $this->hash = $this->hash . "-auth-" . $roleHash;
+                $this->hash = $this->hash . "-auth-" . $roleHash . "-" . $cacheGroup;
             }
+        }
+
+        if($cacheGroup != '') {
+            $this->hash = $this->hash . "-" . $cacheGroup;
         }
 
         add_action('save_post', [$this, 'clearCache']);


### PR DESCRIPTION
This pull request introduces enhancements to the caching mechanism by adding support for a customizable cache group, improving flexibility in cache key generation. The changes primarily affect the `Cache` class and its usage in the `Display` module.

### Enhancements to caching:

* **Support for customizable cache groups in `Cache` class**:
  - Added a new `$cacheGroup` parameter to the `Cache` class constructor, allowing developers to specify a custom cache group. If not provided, it defaults to an empty string. (`source/php/Helper/Cache.php`, [source/php/Helper/Cache.phpL21-R30](diffhunk://#diff-4dbe8bb106a6d155b59d7460f1c9ac7fa4815ad1a43d44971f8e3fa46a8933e0L21-R30))
  - Updated the cache hash generation logic to include the `$cacheGroup` value, ensuring more granular cache key differentiation. (`source/php/Helper/Cache.php`, [source/php/Helper/Cache.phpL49-R64](diffhunk://#diff-4dbe8bb106a6d155b59d7460f1c9ac7fa4815ad1a43d44971f8e3fa46a8933e0L49-R64))

* **Documentation updates**:
  - Updated the `@param` documentation for the `Cache` class to include the new `$cacheGroup` parameter. (`source/php/Helper/Cache.php`, [source/php/Helper/Cache.phpL11-R12](diffhunk://#diff-4dbe8bb106a6d155b59d7460f1c9ac7fa4815ad1a43d44971f8e3fa46a8933e0L11-R12))

### Integration with `Display` module:

* **Passing `$_GET` as a parameter to the cache**:
  - Modified the `outputModule` method in the `Display` class to pass `$_GET` data to the cache, enabling caching behavior that accounts for query string variations. (`source/php/Display.php`, [source/php/Display.phpL480-R481](diffhunk://#diff-0a9b65a1ca3b42eb649330558963fe19e689c1a920befc3e191c0cda607ef9d6L480-R481))